### PR TITLE
Add README and requirements for http2 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,36 @@
+# Broadcast Client
+
+A simple GUI/WebSocket client to fetch broadcast schedules and play TTS audio.
+
+## Setup
+
+Install dependencies (requires Python 3.8+):
+
+```bash
+pip install websockets "httpx[http2]" pillow pystray
+```
+
+`httpx` is used with HTTP/2 enabled. If the optional `h2` package is not installed
+(i.e. if you only run `pip install httpx`), the program will fail with an error
+similar to:
+
+```
+ImportError: Using http2=True, but the 'h2' package is not installed.
+```
+
+Ensure you install `httpx` with the `[http2]` extra to avoid connection loops on
+systems where `h2` is missing.
+
+## Running
+
+Edit `client.cfg` with your `HOST`, `API_KEY` and `DEVICE_ID`, then run:
+
+```bash
+python gui_client.py
+```
+
+or just the scheduler:
+
+```bash
+python scheduler.py
+```

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+websockets
+httpx[http2]
+pystray
+pillow


### PR DESCRIPTION
## Summary
- add README and dependencies list
- document the need for installing `httpx[http2]` to avoid reconnect loops

## Testing
- `python -m py_compile gui_client.py scheduler.py`


------
https://chatgpt.com/codex/tasks/task_e_686f1f38ee448324b6facc6981750bf4