### PR TITLE
Add MAC address to WebSocket handshake

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,10 @@ Edit `client.cfg` with your `HOST`, `API_KEY` and `DEVICE_ID`, then run:
 python gui_client.py
 ```
 
+The client automatically detects the machine's MAC address and includes it when
+connecting to the WebSocket server so each instance can be uniquely
+identified.
+
 or just the scheduler:
 
 ```bash


### PR DESCRIPTION
## Summary
- fetch machine MAC address on startup
- include MAC in WebSocket query and initial message
- document the auto MAC detection in README

## Testing
- `python -m py_compile gui_client.py scheduler.py`

------
https://chatgpt.com/codex/tasks/task_e_686f286db3448324ad572de08574fa39