### PR TITLE
Support single-schedule play from WS command

### DIFF
--- a/gui_client.py
+++ b/gui_client.py
@@ -157,9 +157,9 @@ class WSClient:
                         cfg["DEVICE_ID"] = new_id
                         save_config(cfg)
                         self.update_status(f"Renamed to {new_id}")
-                elif isinstance(data, dict) and data.get("type") == "play_schedule":
+                elif isinstance(data, dict) and data.get("type") in {"play_schedule", "test-broadcast"}:
                     schedule_id = data.get("schedule_id")
-                    test = bool(data.get("test"))
+                    test = bool(data.get("test")) or data.get("type") == "test-broadcast"
                     if schedule_id is not None:
                         await self.play_schedule_once(schedule_id, test=test)
                 else:


### PR DESCRIPTION
## Summary
- add play_schedule_once helper in `gui_client.py`
- trigger playback when receiving `play_schedule` WS message

## Testing
- `python -m py_compile gui_client.py scheduler.py`
- `flake8 gui_client.py scheduler.py` *(fails: E501 line too long)*

------
https://chatgpt.com/codex/tasks/task_e_686f54e2c2708324b69abe39a6f9562d