### PR TITLE
Handle non-JSON websocket messages

### DIFF
--- a/gui_client.py
+++ b/gui_client.py
@@ -147,8 +147,12 @@ class WSClient:
                 try:
                     data = json.loads(msg)
                 except Exception:
-                    print("[WS]", msg)
-                    continue
+                    try:
+                        import ast
+                        data = ast.literal_eval(msg)
+                    except Exception:
+                        print("[WS]", msg)
+                        continue
 
                 if isinstance(data, dict) and data.get("type") == "rename":
                     new_id = data.get("device_id")


### PR DESCRIPTION
## Summary
- parse incoming messages using `ast.literal_eval` if JSON parsing fails

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python -m compileall -q .`


------
https://chatgpt.com/codex/tasks/task_e_686f5c49daf48324b9d0c576d0a1d256