### PR TITLE
Implement caching for media playback

### DIFF
--- a/vlc_embed.py
+++ b/vlc_embed.py
@@ -4,9 +4,40 @@ import sys
 import ctypes
 import tkinter as tk
 import vlc
+import pathlib
+import hashlib
+from urllib.parse import urlparse
+import httpx
 
 
 DEFAULT_URL = "http://nas.3no.kr/test.mp4"
+
+# Directory to store cached media files
+CACHE_DIR = pathlib.Path(__file__).with_name("cache")
+
+
+def cache_media(url: str) -> str:
+    """Return a local path to the media, downloading it if necessary."""
+    parsed = urlparse(url)
+    if parsed.scheme in {"file", ""}:
+        return url
+
+    CACHE_DIR.mkdir(exist_ok=True)
+    ext = pathlib.Path(parsed.path).suffix or ".bin"
+    name = hashlib.sha1(url.encode()).hexdigest() + ext
+    path = CACHE_DIR / name
+    if path.exists():
+        return str(path)
+
+    try:
+        with httpx.Client(timeout=60.0) as cli:
+            r = cli.get(url)
+            r.raise_for_status()
+            path.write_bytes(r.content)
+        return str(path)
+    except Exception as e:  # noqa: BLE001
+        print(f"Failed to cache {url}: {e}")
+        return url
 
 
 def _attach_handle(player: vlc.MediaPlayer, handle: int) -> None:
@@ -30,7 +61,8 @@ def play_media(url: str) -> None:
 
     instance = vlc.Instance()
     player = instance.media_player_new()
-    media = instance.media_new(url)
+    media_url = cache_media(url)
+    media = instance.media_new(media_url)
     player.set_media(media)
 
     root.update_idletasks()

--- a/vlc_playlist.py
+++ b/vlc_playlist.py
@@ -5,8 +5,38 @@ import ctypes
 import tkinter as tk
 import vlc
 from urllib.parse import urlparse, urlunparse
+import pathlib
+import hashlib
+import httpx
 
 DEFAULT_IMAGE_DURATION = 5
+
+# Directory used to store cached media files
+CACHE_DIR = pathlib.Path(__file__).with_name("cache")
+
+
+def cache_media(url: str) -> str:
+    """Return a local path to ``url``, downloading it if needed."""
+    parsed = urlparse(url)
+    if parsed.scheme in {"file", ""}:
+        return url
+
+    CACHE_DIR.mkdir(exist_ok=True)
+    ext = pathlib.Path(parsed.path).suffix or ".bin"
+    name = hashlib.sha1(url.encode()).hexdigest() + ext
+    path = CACHE_DIR / name
+    if path.exists():
+        return str(path)
+
+    try:
+        with httpx.Client(timeout=60.0) as cli:
+            r = cli.get(url)
+            r.raise_for_status()
+            path.write_bytes(r.content)
+        return str(path)
+    except Exception as e:  # noqa: BLE001
+        print(f"Failed to cache {url}: {e}")
+        return url
 
 
 def _attach_handle(player: vlc.MediaPlayer, handle: int) -> None:
@@ -68,7 +98,8 @@ def play_playlist(items: list) -> None:
             root.after(0, play_next)
             return
 
-        media = instance.media_new(url)
+        media_url = cache_media(url)
+        media = instance.media_new(media_url)
         player.set_media(media)
         player.play()
 


### PR DESCRIPTION
## Summary
- add cache helpers to `vlc_embed.py` and `vlc_playlist.py`
- use cached files if available, otherwise download and store in cache before playing

## Testing
- `python -m py_compile *.py`

------
https://chatgpt.com/codex/tasks/task_e_68726eb1ca748324b9780cdf7f6640bb