### PR TITLE
Add play-media support

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,3 +45,8 @@ in a fullscreen embedded VLC window. The helper script attaches VLC to a
 Tkinter window using the correct API for Windows, macOS, or X11-based
 Linux/Raspbian environments.
 If no stream URL is supplied, it defaults to `http://nas.3no.kr/test.mp4`.
+
+The client also handles playlist messages. When a playlist is received it
+is passed to `vlc_playlist.py` for fullscreen playback. A subsequent
+`play-media` command with a `media_id` will immediately start playback of
+the matching playlist item.

--- a/vlc_playlist.py
+++ b/vlc_playlist.py
@@ -66,7 +66,7 @@ def fix_media_url(url: str) -> str:
     return url
 
 
-def play_playlist(items: list) -> None:
+def play_playlist(items: list, *, start_index: int = 0) -> None:
     root = tk.Tk()
     root.attributes("-fullscreen", True)
     root.configure(background="black")
@@ -78,7 +78,7 @@ def play_playlist(items: list) -> None:
     root.update_idletasks()
     _attach_handle(player, frame.winfo_id())
 
-    idx = 0
+    idx = max(0, int(start_index))
 
     if not items:
         root.destroy()
@@ -144,8 +144,14 @@ if __name__ == "__main__":
         print("Usage: vlc_playlist.py playlist.json")
         sys.exit(1)
     with open(sys.argv[1], "r", encoding="utf-8") as f:
-        items = json.load(f)
+        data = json.load(f)
+    if isinstance(data, dict):
+        items = data.get("items", [])
+        start_index = int(data.get("start_index", 0))
+    else:
+        items = data
+        start_index = 0
     if not isinstance(items, list):
         print("Invalid playlist format")
         sys.exit(1)
-    play_playlist(items)
+    play_playlist(items, start_index=start_index)


### PR DESCRIPTION
## Summary
- add playlist controls for play-media command
- store playlist items in client
- allow starting playlist at an arbitrary index
- document playlist and play-media handling

## Testing
- `python -m py_compile gui_client.py vlc_playlist.py scheduler.py vlc_embed.py`

------
https://chatgpt.com/codex/tasks/task_e_68728cc1c9b883248fa4a7e315d9bb05