### PR TITLE
Disable VLC caching

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ in a fullscreen embedded VLC window. The helper script attaches VLC to a
 Tkinter window using the correct API for Windows, macOS, or X11-based
 Linux/Raspbian environments.
 If no stream URL is supplied, it defaults to `http://nas.3no.kr/test.mp4`.
+Media files are streamed directly from their URLs with no local caching.
 
 The client also handles playlist messages. When a playlist is received it
 is passed to `vlc_playlist.py` for fullscreen playback. A subsequent

--- a/vlc_embed.py
+++ b/vlc_embed.py
@@ -4,40 +4,15 @@ import sys
 import ctypes
 import tkinter as tk
 import vlc
-import pathlib
-import hashlib
-from urllib.parse import urlparse
-import httpx
 
 
 DEFAULT_URL = "http://nas.3no.kr/test.mp4"
 
-# Directory to store cached media files
-CACHE_DIR = pathlib.Path(__file__).with_name("cache")
 
 
 def cache_media(url: str) -> str:
-    """Return a local path to the media, downloading it if necessary."""
-    parsed = urlparse(url)
-    if parsed.scheme in {"file", ""}:
-        return url
-
-    CACHE_DIR.mkdir(exist_ok=True)
-    ext = pathlib.Path(parsed.path).suffix or ".bin"
-    name = hashlib.sha1(url.encode()).hexdigest() + ext
-    path = CACHE_DIR / name
-    if path.exists():
-        return str(path)
-
-    try:
-        with httpx.Client(timeout=60.0) as cli:
-            r = cli.get(url)
-            r.raise_for_status()
-            path.write_bytes(r.content)
-        return str(path)
-    except Exception as e:  # noqa: BLE001
-        print(f"Failed to cache {url}: {e}")
-        return url
+    """Return the given URL without caching it locally."""
+    return url
 
 
 def _attach_handle(player: vlc.MediaPlayer, handle: int) -> None:

--- a/vlc_playlist.py
+++ b/vlc_playlist.py
@@ -15,38 +15,14 @@ import ctypes
 import tkinter as tk
 import vlc
 from urllib.parse import urlparse, urlunparse
-import pathlib
-import hashlib
-import httpx
 
 DEFAULT_IMAGE_DURATION = 5
 
-# Directory used to store cached media files
-CACHE_DIR = pathlib.Path(__file__).with_name("cache")
 
 
 def cache_media(url: str) -> str:
-    """Return a local path to ``url``, downloading it if needed."""
-    parsed = urlparse(url)
-    if parsed.scheme in {"file", ""}:
-        return url
-
-    CACHE_DIR.mkdir(exist_ok=True)
-    ext = pathlib.Path(parsed.path).suffix or ".bin"
-    name = hashlib.sha1(url.encode()).hexdigest() + ext
-    path = CACHE_DIR / name
-    if path.exists():
-        return str(path)
-
-    try:
-        with httpx.Client(timeout=60.0) as cli:
-            r = cli.get(url)
-            r.raise_for_status()
-            path.write_bytes(r.content)
-        return str(path)
-    except Exception as e:  # noqa: BLE001
-        print(f"Failed to cache {url}: {e}")
-        return url
+    """Return the given URL without caching it locally."""
+    return url
 
 
 def _attach_handle(player: vlc.MediaPlayer, handle: int) -> None:


### PR DESCRIPTION
## Summary
- disable local caching in `vlc_embed.py` and `vlc_playlist.py`
- update README to mention streaming without caching

## Testing
- `python -m py_compile vlc_embed.py vlc_playlist.py scheduler.py gui_client.py`

------
https://chatgpt.com/codex/tasks/task_e_687496c8a340832489ac3bd55ffc13f7