### PR TITLE
Handle orientation degrees in config

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,9 +47,10 @@ Linux/Raspbian environments.
 If no stream URL is supplied, it defaults to `http://nas.3no.kr/test.mp4`.
 
 Config messages may also include `Resolution` (e.g. `"1920x1080"`) and
-`Orientation` (0-4) fields.  When present, the client attempts to update the
-system's display settings accordingly on Windows and Linux (including
-Raspberry Pi and Orange Pi) using platform specific commands.
+`Orientation` fields.  The orientation value can be one of `0`, `90`, `180` or
+`270` degrees. When present, the client attempts to update the system's display
+settings accordingly on Windows and Linux (including Raspberry Pi and
+Orange Pi) using platform specific commands.
 
 The client also handles playlist messages. When a playlist is received it
 is passed to `vlc_playlist.py` for fullscreen playback. A subsequent

--- a/display_config.py
+++ b/display_config.py
@@ -4,25 +4,42 @@ import ctypes
 from typing import Optional
 
 
-def set_display_config(resolution: Optional[str] = None, orientation: Optional[int] = None) -> None:
-    """Set display resolution and orientation if possible."""
+ORI_DEG_MAP = {0: 0, 90: 1, 180: 2, 270: 3}
+
+
+def set_display_config(
+    resolution: Optional[str] = None, orientation: Optional[int] = None
+) -> None:
+    """Set display resolution and orientation if possible.
+
+    ``orientation`` can be supplied either as the original index values
+    ``0``-``3`` or as rotation degrees ``0``, ``90``, ``180`` and ``270``.
+    """
     width: Optional[int] = None
     height: Optional[int] = None
     if resolution:
         try:
-            w, h = resolution.lower().split('x')
+            w, h = resolution.lower().split("x")
             width = int(w)
             height = int(h)
         except Exception:
             width = height = None
+
+    orientation_idx: Optional[int] = None
+    if orientation is not None:
+        try:
+            ori_val = int(orientation)
+            orientation_idx = ORI_DEG_MAP.get(ori_val, ori_val)
+        except Exception:
+            orientation_idx = None
     if sys.platform.startswith('win'):
         try:
-            _set_windows_display(width, height, orientation)
+            _set_windows_display(width, height, orientation_idx)
         except Exception as e:
             print(f"Failed to set Windows display: {e}")
     else:
         try:
-            _set_xrandr_display(width, height, orientation)
+            _set_xrandr_display(width, height, orientation_idx)
         except Exception as e:
             print(f"Failed to set xrandr display: {e}")
 

--- a/gui_client.py
+++ b/gui_client.py
@@ -275,6 +275,11 @@ class WSClient:
                     self.playmode = playmode
                     res = data.get("Resolution") or data.get("resolution")
                     orient = data.get("Orientation")
+                    if orient is not None:
+                        try:
+                            orient = int(orient)
+                        except Exception:
+                            orient = None
                     if res or orient is not None:
                         display_config.set_display_config(res, orient)
                     self.device_enabled = enabled


### PR DESCRIPTION
## Summary
- support degrees for orientation settings in config
- update README to document new orientation values
- parse orientation integers in gui_client before applying

## Testing
- `python -m py_compile gui_client.py display_config.py scheduler.py vlc_embed.py vlc_playlist.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68752630827883249c0d72389801c44f