### PR TITLE
Handle portrait mode in VLC windows

### DIFF
--- a/vlc_embed.py
+++ b/vlc_embed.py
@@ -81,7 +81,14 @@ def run(url: str = DEFAULT_URL) -> None:
     global _root, _player
     root = tk.Tk()
     _root = root
-    root.attributes("-fullscreen", True)
+    root.update_idletasks()
+    screen_w = root.winfo_screenwidth()
+    screen_h = root.winfo_screenheight()
+    if screen_h > screen_w:
+        # Portrait displays sometimes fail with fullscreen. Size by height.
+        root.geometry(f"{screen_h}x{screen_h}+0+0")
+    else:
+        root.attributes("-fullscreen", True)
     root.configure(background="black")
     frame = tk.Frame(root, background="black")
     frame.pack(fill=tk.BOTH, expand=True)

--- a/vlc_playlist.py
+++ b/vlc_playlist.py
@@ -133,7 +133,13 @@ def run(path: str) -> None:
 
     root = tk.Tk()
     _root = root
-    root.attributes("-fullscreen", True)
+    root.update_idletasks()
+    screen_w = root.winfo_screenwidth()
+    screen_h = root.winfo_screenheight()
+    if screen_h > screen_w:
+        root.geometry(f"{screen_h}x{screen_h}+0+0")
+    else:
+        root.attributes("-fullscreen", True)
     root.configure(background="black")
     frame = tk.Frame(root, background="black")
     frame.pack(fill=tk.BOTH, expand=True)


### PR DESCRIPTION
## Summary
- adjust VLC fullscreen handling for portrait monitors
- apply same logic to playlist playback

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_687532f4b0d883248d6ef1a4a5e11f31