### PR TITLE
Implement VLC geometry settings

### DIFF
--- a/vlc_embed.py
+++ b/vlc_embed.py
@@ -76,15 +76,32 @@ _root: tk.Tk | None = None
 _player: vlc.MediaPlayer | None = None
 
 
-def run(url: str = DEFAULT_URL) -> None:
-    """Play ``url`` in an embedded fullscreen window."""
+def run(
+    url: str = DEFAULT_URL,
+    *,
+    x: int | None = None,
+    y: int | None = None,
+    width: int | None = None,
+    height: int | None = None,
+) -> None:
+    """Play ``url`` in a fullscreen window with an embedded player.
+
+    ``x``/``y`` specify the top left corner of the embedded player within the
+    fullscreen window and ``width``/``height`` control its size.  When no
+    geometry is provided the player fills the entire screen.
+    """
     global _root, _player
     root = tk.Tk()
     _root = root
     root.attributes("-fullscreen", True)
     root.configure(background="black")
     frame = tk.Frame(root, background="black")
-    frame.pack(fill=tk.BOTH, expand=True)
+    if width and height:
+        fx = int(x) if x is not None else 0
+        fy = int(y) if y is not None else 0
+        frame.place(x=fx, y=fy, width=int(width), height=int(height))
+    else:
+        frame.pack(fill=tk.BOTH, expand=True)
     progress_var = tk.StringVar()
     progress_label = tk.Label(root, textvariable=progress_var, fg="white", bg="black")
     progress_label.pack(side="bottom", fill="x")

--- a/vlc_playlist.py
+++ b/vlc_playlist.py
@@ -107,8 +107,20 @@ def fix_media_url(url: str) -> str:
     return url
 
 
-def run(path: str) -> None:
-    """Play playlist defined in ``path`` and reload when it changes."""
+def run(
+    path: str,
+    *,
+    x: int | None = None,
+    y: int | None = None,
+    width: int | None = None,
+    height: int | None = None,
+) -> None:
+    """Play playlist defined in ``path`` and reload when it changes.
+
+    The player always opens a fullscreen window.  When ``width`` and ``height``
+    are supplied the VLC player is embedded at ``x``, ``y`` with the given size.
+    Otherwise the player fills the entire window.
+    """
 
     def load() -> tuple[list, int]:
         try:
@@ -136,7 +148,12 @@ def run(path: str) -> None:
     root.attributes("-fullscreen", True)
     root.configure(background="black")
     frame = tk.Frame(root, background="black")
-    frame.pack(fill=tk.BOTH, expand=True)
+    if width and height:
+        fx = int(x) if x is not None else 0
+        fy = int(y) if y is not None else 0
+        frame.place(x=fx, y=fy, width=int(width), height=int(height))
+    else:
+        frame.pack(fill=tk.BOTH, expand=True)
     progress_var = tk.StringVar()
     progress_label = tk.Label(root, textvariable=progress_var, fg="white", bg="black")
     progress_label.pack(side="bottom", fill="x")


### PR DESCRIPTION
## Summary
- add position and size parameters to `vlc_embed.run`
- add geometry controls to playlist playback
- allow gui client to pass VLC coordinates from config
- store `VlcX`, `VlcY`, `VlcWidth` and `VlcHeight` from server config messages
- embed VLC in custom region of fullscreen window

## Testing
- `python -m py_compile display_config.py gui_client.py scheduler.py vlc_embed.py vlc_playlist.py`


------
https://chatgpt.com/codex/tasks/task_e_6875e4fae81c832495f4f87034e9113e