### PR TITLE
Store cached & temp files in run directory

### DIFF
--- a/gui_client.py
+++ b/gui_client.py
@@ -17,6 +17,9 @@ import vlc_embed
 import vlc_playlist
 import display_config
 
+# Directory where the script or executable is running
+RUN_DIR = pathlib.Path(sys.argv[0]).resolve().parent
+
 """Simple Tk GUI client with a system tray icon.
 
 서버 연결 후 `/broadcast-schedules` 를 호출해 방송 예약 목록을 출력한다.
@@ -148,7 +151,7 @@ class WSClient:
         # Starting a new playlist, ensure any previous VLC playback is stopped
         self.stop_vlc()
 
-        tmp = tempfile.NamedTemporaryFile(delete=False, suffix=".json", mode="w", encoding="utf-8")
+        tmp = tempfile.NamedTemporaryFile(delete=False, suffix=".json", mode="w", encoding="utf-8", dir=RUN_DIR)
         json.dump(data, tmp)
         tmp.flush()
         tmp.close()
@@ -208,7 +211,7 @@ class WSClient:
                 r = await cli.get(url)
                 r.raise_for_status()
 
-            tmp = tempfile.NamedTemporaryFile(delete=False, suffix=".mp3")
+            tmp = tempfile.NamedTemporaryFile(delete=False, suffix=".mp3", dir=RUN_DIR)
             tmp.write(r.content)
             tmp.flush()
             tmp.close()

--- a/scheduler.py
+++ b/scheduler.py
@@ -19,6 +19,9 @@ if getattr(sys, "frozen", False) and sys.platform == "win32":
 else:
     CFG_PATH = pathlib.Path(__file__).with_name("client.cfg")
 
+# Directory to store temporary media next to the running executable/script
+RUN_DIR = pathlib.Path(sys.argv[0]).resolve().parent
+
 
 def load_config() -> Dict[str, Any]:
     if not CFG_PATH.exists():
@@ -91,7 +94,7 @@ def set_volume(level: int) -> None:
 
 def play_mp3(data: bytes) -> None:
     """Play MP3 data using an available backend without blocking."""
-    tmp = tempfile.NamedTemporaryFile(delete=False, suffix=".mp3")
+    tmp = tempfile.NamedTemporaryFile(delete=False, suffix=".mp3", dir=RUN_DIR)
     tmp.write(data)
     tmp.flush()
     tmp.close()

--- a/vlc_embed.py
+++ b/vlc_embed.py
@@ -16,8 +16,9 @@ from PIL import Image, ImageTk, ImageSequence
 
 DEFAULT_URL = "http://nas.3no.kr/test.mp4"
 
-# Directory to store cached media files
-CACHE_DIR = pathlib.Path(__file__).with_name("cache")
+# Directory to store cached media files next to the running executable/script
+RUN_DIR = pathlib.Path(sys.argv[0]).resolve().parent
+CACHE_DIR = RUN_DIR / "cache"
 
 
 def cache_media(url: str, progress_cb=None) -> str:

--- a/vlc_playlist.py
+++ b/vlc_playlist.py
@@ -26,8 +26,9 @@ from PIL import Image, ImageTk, ImageSequence
 
 DEFAULT_IMAGE_DURATION = 5
 
-# Directory used to store cached media files
-CACHE_DIR = pathlib.Path(__file__).with_name("cache")
+# Directory used to store cached media files next to the running executable/script
+RUN_DIR = pathlib.Path(sys.argv[0]).resolve().parent
+CACHE_DIR = RUN_DIR / "cache"
 
 
 _root: tk.Tk | None = None


### PR DESCRIPTION
## Summary
- keep cache and temp files with the running script or executable
- ensure playlist and mp3 downloads are stored next to the executable

## Testing
- `python -m py_compile *.py`

------
https://chatgpt.com/codex/tasks/task_e_6875f07b1cfc83248843ec886952cbc3