### PR TITLE
Fix union types for Python <3.10

### DIFF
--- a/display_config.py
+++ b/display_config.py
@@ -1,10 +1,10 @@
 import sys
 import subprocess
 import ctypes
-from typing import Optional
+from typing import Optional, Union
 
 
-def set_display_config(resolution: Optional[str] = None, orientation: Optional[int | str] = None) -> None:
+def set_display_config(resolution: Optional[str] = None, orientation: Optional[Union[int, str]] = None) -> None:
     """Set display resolution and orientation if possible."""
     width: Optional[int] = None
     height: Optional[int] = None

--- a/gui_client.py
+++ b/gui_client.py
@@ -240,7 +240,7 @@ class WSClient:
                 await asyncio.sleep(backoff)
                 backoff = min(backoff * 2, 60)
 
-    async def update_schedules(self, *, start_scheduler: bool | None = None) -> None:
+    async def update_schedules(self, *, start_scheduler: Optional[bool] = None) -> None:
         """Fetch schedules from the server and update the scheduler list.
 
         ``start_scheduler`` defaults to ``True`` unless ``self.playmode`` is 2.

--- a/vlc_embed.py
+++ b/vlc_embed.py
@@ -75,8 +75,8 @@ def _attach_handle(player: vlc.MediaPlayer, handle: int) -> None:
         player.set_xwindow(handle)
 
 
-_root: tk.Tk | None = None
-_player: vlc.MediaPlayer | None = None
+_root: Optional[tk.Tk] = None
+_player: Optional[vlc.MediaPlayer] = None
 _gui_images: List[Dict[str, any]] = []
 _gui_labels: List[Dict[str, any]] = []
 
@@ -91,7 +91,7 @@ def fix_media_url(url: str) -> str:
     return url
 
 
-def _load_image_frames(url: str, width: int | None, height: int | None) -> tuple[list, list]:
+def _load_image_frames(url: str, width: Optional[int], height: Optional[int]) -> tuple[List, List]:
     """Return a list of PhotoImage frames and their durations."""
     try:
         if urlparse(url).scheme in {"http", "https"}:
@@ -186,10 +186,10 @@ def set_gui_images(images: List[Dict[str, any]]) -> None:
 def run(
     url: str = DEFAULT_URL,
     *,
-    x: int | None = None,
-    y: int | None = None,
-    width: int | None = None,
-    height: int | None = None,
+    x: Optional[int] = None,
+    y: Optional[int] = None,
+    width: Optional[int] = None,
+    height: Optional[int] = None,
 ) -> None:
     """Play ``url`` in a fullscreen window with an embedded player.
 

--- a/vlc_playlist.py
+++ b/vlc_playlist.py
@@ -31,19 +31,19 @@ RUN_DIR = pathlib.Path(sys.argv[0]).resolve().parent
 CACHE_DIR = RUN_DIR / "cache"
 
 
-_root: tk.Tk | None = None
-_player: vlc.MediaPlayer | None = None
-_after_id: str | None = None
-_check_id: str | None = None
-_playlist_path: str | None = None
-_items: list | None = None
+_root: Optional[tk.Tk] = None
+_player: Optional[vlc.MediaPlayer] = None
+_after_id: Optional[str] = None
+_check_id: Optional[str] = None
+_playlist_path: Optional[str] = None
+_items: Optional[list] = None
 _idx: int = 0
 _last_mtime: float = 0.0
 _gui_images: List[Dict[str, any]] = []
 _gui_labels: List[Dict[str, any]] = []
 
 
-def _load_image_frames(url: str, width: int | None, height: int | None) -> tuple[list, list]:
+def _load_image_frames(url: str, width: Optional[int], height: Optional[int]) -> tuple[List, List]:
     try:
         if urlparse(url).scheme in {"http", "https"}:
             r = httpx.get(url, timeout=30)
@@ -205,10 +205,10 @@ def fix_media_url(url: str) -> str:
 def run(
     path: str,
     *,
-    x: int | None = None,
-    y: int | None = None,
-    width: int | None = None,
-    height: int | None = None,
+    x: Optional[int] = None,
+    y: Optional[int] = None,
+    width: Optional[int] = None,
+    height: Optional[int] = None,
 ) -> None:
     """Play playlist defined in ``path`` and reload when it changes.
 
@@ -217,7 +217,7 @@ def run(
     Otherwise the player fills the entire window.
     """
 
-    def load() -> tuple[list, int]:
+    def load() -> tuple[List, int]:
         try:
             with open(path, "r", encoding="utf-8") as f:
                 data = json.load(f)


### PR DESCRIPTION
## Summary
- support Python versions prior to 3.10 by removing the `|` union operator
- update all affected functions and variable annotations

## Testing
- `python -m py_compile *.py`
- `python gui_client.py` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_6876682de6e083248dd3041b5e9c64be