### PR TITLE
Fix VLC Xlib thread warning on Orange Pi 5

### DIFF
--- a/vlc_embed.py
+++ b/vlc_embed.py
@@ -245,7 +245,8 @@ def run(
     progress_label.place(relx=0.5, rely=0.5, anchor="center")
     progress_label.place_forget()
 
-    instance = vlc.Instance()
+    # Disable direct Xlib usage to avoid threading issues on some platforms
+    instance = vlc.Instance("--no-xlib")
     player = instance.media_player_new()
     _player = player
     def on_progress(done: int, total: int, speed: float, elapsed: float, err: Optional[Exception]) -> None:

--- a/vlc_playlist.py
+++ b/vlc_playlist.py
@@ -285,7 +285,8 @@ def run(
     progress_label.place(relx=0.5, rely=0.5, anchor="center")
     progress_label.place_forget()
 
-    instance = vlc.Instance()
+    # Disable direct Xlib usage to avoid threading issues on some platforms
+    instance = vlc.Instance("--no-xlib")
     player = instance.media_player_new()
     _player = player
     root.update_idletasks()


### PR DESCRIPTION
## Summary
- disable Xlib in VLC instance creation

## Testing
- `python -m py_compile vlc_embed.py vlc_playlist.py`


------
https://chatgpt.com/codex/tasks/task_e_68790947170c8324aa7c541c37b02294