### PR TITLE
Persist MAC address in config

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,9 +29,10 @@ Edit `client.cfg` with your `HOST`, `API_KEY` and `DEVICE_ID`, then run:
 python gui_client.py
 ```
 
-The client automatically detects the machine's MAC address and includes it when
-connecting to the WebSocket server so each instance can be uniquely
-identified.
+The client stores the machine's MAC address in `client.cfg`. On the first run
+the address is detected and saved under `MAC_ADDRESS`. This value is reused on
+subsequent runs so each instance can be consistently identified even if the
+hardware's MAC address changes across reboots.
 
 or just the scheduler:
 

--- a/gui_client.py
+++ b/gui_client.py
@@ -61,6 +61,7 @@ def load_config():
             "HOST": "http://example.com:65000",
             "API_KEY": "",
             "DEVICE_ID": "PC-CLIENT",
+            "MAC_ADDRESS": get_mac_address(),
         }
         CFG_PATH.write_text(json.dumps(sample, indent=2), encoding="utf-8")
         print(f"Created {CFG_PATH}. Fill in API_KEY and run again.")
@@ -78,7 +79,12 @@ cfg = load_config()
 HOST = cfg["HOST"].rstrip("/")
 API_KEY = cfg["API_KEY"]
 DEVICE_ID = cfg["DEVICE_ID"]
-MAC_ADDRESS = get_mac_address()
+if cfg.get("MAC_ADDRESS"):
+    MAC_ADDRESS = str(cfg["MAC_ADDRESS"])
+else:
+    MAC_ADDRESS = get_mac_address()
+    cfg["MAC_ADDRESS"] = MAC_ADDRESS
+    save_config(cfg)
 
 
 class WSClient:


### PR DESCRIPTION
## Summary
- store a generated MAC address in `client.cfg` on first run
- reuse `MAC_ADDRESS` from config on subsequent runs
- document persistent MAC handling in README

## Testing
- `python -m py_compile gui_client.py scheduler.py display_config.py vlc_embed.py vlc_playlist.py`
- `pip install -r requirements.txt`
- `python gui_client.py` *(fails: Created client.cfg. Fill in API_KEY and run again.)*


------
https://chatgpt.com/codex/tasks/task_e_687a65db5378832496194f660e4bbb92