### PR TITLE
Implement dual monitor playback support

### DIFF
--- a/display_config.py
+++ b/display_config.py
@@ -4,8 +4,13 @@ import ctypes
 from typing import Optional, Union
 
 
-def set_display_config(resolution: Optional[str] = None, orientation: Optional[Union[int, str]] = None) -> None:
-    """Set display resolution and orientation if possible."""
+def set_display_config(
+    resolution: Optional[str] = None,
+    orientation: Optional[Union[int, str]] = None,
+    *,
+    monitor: int = 1,
+) -> None:
+    """Set display resolution and orientation for the given ``monitor`` if possible."""
     width: Optional[int] = None
     height: Optional[int] = None
     if resolution:
@@ -22,33 +27,33 @@ def set_display_config(resolution: Optional[str] = None, orientation: Optional[U
             orientation = None
     if sys.platform.startswith('win'):
         try:
-            _set_windows_display(width, height, orientation)
+            _set_windows_display(width, height, orientation, monitor)
         except Exception as e:
             print(f"Failed to set Windows display: {e}")
     else:
         try:
-            _set_xrandr_display(width, height, orientation)
+            _set_xrandr_display(width, height, orientation, monitor)
         except Exception as e:
             print(f"Failed to set xrandr display: {e}")
 
 
-def _set_xrandr_display(width: Optional[int], height: Optional[int], orientation: Optional[int]) -> None:
+def _set_xrandr_display(
+    width: Optional[int],
+    height: Optional[int],
+    orientation: Optional[int],
+    monitor: int,
+) -> None:
     output = subprocess.run(['xrandr'], capture_output=True, text=True)
     if output.returncode != 0:
         return
-    primary = None
+    outputs = []
     for line in output.stdout.splitlines():
-        if ' connected primary' in line:
-            primary = line.split()[0]
-            break
-    if not primary:
-        for line in output.stdout.splitlines():
-            if ' connected' in line:
-                primary = line.split()[0]
-                break
-    if not primary:
+        if ' connected' in line:
+            outputs.append(line.split()[0])
+    if not outputs or monitor < 1 or monitor > len(outputs):
         return
-    cmd = ['xrandr', '--output', primary]
+    name = outputs[monitor - 1]
+    cmd = ['xrandr', '--output', name]
     if width and height:
         cmd += ['--mode', f'{width}x{height}']
     if orientation is not None:
@@ -116,11 +121,17 @@ if sys.platform.startswith('win'):
         270: 3,
     }
 
-    def _set_windows_display(width: Optional[int], height: Optional[int], orientation: Optional[int]) -> None:
+    def _set_windows_display(
+        width: Optional[int],
+        height: Optional[int],
+        orientation: Optional[int],
+        monitor: int,
+    ) -> None:
         user32 = ctypes.windll.user32
         dm = DEVMODE()
         dm.dmSize = ctypes.sizeof(DEVMODE)
-        if user32.EnumDisplaySettingsW(None, ENUM_CURRENT_SETTINGS, ctypes.byref(dm)) == 0:
+        dev_name = f"\\\\.\\DISPLAY{monitor}"
+        if user32.EnumDisplaySettingsW(dev_name, ENUM_CURRENT_SETTINGS, ctypes.byref(dm)) == 0:
             return
         changed = False
         if orientation is not None:
@@ -147,7 +158,12 @@ if sys.platform.startswith('win'):
                 dm.dmFields |= DM_PELSWIDTH | DM_PELSHEIGHT
                 changed = True
         if changed:
-            user32.ChangeDisplaySettingsW(ctypes.byref(dm), CDS_UPDATEREGISTRY)
+            user32.ChangeDisplaySettingsExW(dev_name, ctypes.byref(dm), None, CDS_UPDATEREGISTRY, None)
 else:
-    def _set_windows_display(width: Optional[int], height: Optional[int], orientation: Optional[int]) -> None:
+    def _set_windows_display(
+        width: Optional[int],
+        height: Optional[int],
+        orientation: Optional[int],
+        monitor: int,
+    ) -> None:
         pass

--- a/gui_client.py
+++ b/gui_client.py
@@ -98,14 +98,29 @@ class WSClient:
         self.playlist_items = []
         self.device_id = DEVICE_ID
         self.device_enabled = True
-        self.vlc_thread = None
-        self.playlist_thread = None
-        self.playlist_path = None
+        self.monitors = {
+            1: {
+                "vlc_thread": None,
+                "playlist_thread": None,
+                "playlist_path": None,
+                "vlc_x": None,
+                "vlc_y": None,
+                "vlc_width": None,
+                "vlc_height": None,
+                "playlist_items": [],
+            },
+            2: {
+                "vlc_thread": None,
+                "playlist_thread": None,
+                "playlist_path": None,
+                "vlc_x": None,
+                "vlc_y": None,
+                "vlc_width": None,
+                "vlc_height": None,
+                "playlist_items": [],
+            },
+        }
         self.playmode = 0
-        self.vlc_x = None
-        self.vlc_y = None
-        self.vlc_width = None
-        self.vlc_height = None
         self.gui_images = []
 
     def start(self):
@@ -119,82 +134,94 @@ class WSClient:
             self.scheduler_thread.join(timeout=1)
         self.stop_vlc()
 
-    def start_vlc(self, url: Optional[str] = None) -> None:
-        """Launch VLC to play ``url`` using a thread."""
-        if self.vlc_thread and self.vlc_thread.is_alive():
+    def start_vlc(self, url: Optional[str] = None, monitor: int = 1) -> None:
+        """Launch VLC to play ``url`` on ``monitor`` using a thread."""
+        mon = self.monitors.get(monitor)
+        if not mon:
+            return
+        if mon["vlc_thread"] and mon["vlc_thread"].is_alive():
             return
         if not url:
             return
-        target_url = url
         kwargs = {
-            "x": self.vlc_x,
-            "y": self.vlc_y,
-            "width": self.vlc_width,
-            "height": self.vlc_height,
+            "x": mon["vlc_x"],
+            "y": mon["vlc_y"],
+            "width": mon["vlc_width"],
+            "height": mon["vlc_height"],
+            "monitor": monitor,
         }
-        self.vlc_thread = threading.Thread(
-            target=vlc_embed.run, args=(target_url,), kwargs=kwargs, daemon=True
+        mon["vlc_thread"] = threading.Thread(
+            target=vlc_embed.run, args=(url,), kwargs=kwargs, daemon=True
         )
-        self.vlc_thread.start()
-        vlc_embed.set_gui_images(self.gui_images)
+        mon["vlc_thread"].start()
+        vlc_embed.set_gui_images(self.gui_images, monitor)
 
-    def start_vlc_playlist(self, items: list, start_index: int = 0) -> None:
-        """Launch or update VLC playlist without closing the window."""
+    def start_vlc_playlist(self, items: list, start_index: int = 0, monitor: int = 1) -> None:
+        """Launch or update VLC playlist on ``monitor`` without closing the window."""
+
+        mon = self.monitors.get(monitor)
+        if not mon:
+            return
 
         if not items:
-            self.stop_vlc()
+            self.stop_vlc(monitor)
             return
 
         data = {"items": items, "start_index": int(start_index)}
-        if self.playlist_thread and self.playlist_thread.is_alive() and self.playlist_path:
+        if mon["playlist_thread"] and mon["playlist_thread"].is_alive() and mon["playlist_path"]:
             try:
-                with open(self.playlist_path, "w", encoding="utf-8") as f:
+                with open(mon["playlist_path"], "w", encoding="utf-8") as f:
                     json.dump(data, f)
                 return
             except Exception:
                 pass
 
-        # Starting a new playlist, ensure any previous VLC playback is stopped
-        self.stop_vlc()
+        self.stop_vlc(monitor)
 
         tmp = tempfile.NamedTemporaryFile(delete=False, suffix=".json", mode="w", encoding="utf-8", dir=RUN_DIR)
         json.dump(data, tmp)
         tmp.flush()
         tmp.close()
-        self.playlist_path = tmp.name
+        mon["playlist_path"] = tmp.name
         kwargs = {
-            "x": self.vlc_x,
-            "y": self.vlc_y,
-            "width": self.vlc_width,
-            "height": self.vlc_height,
+            "x": mon["vlc_x"],
+            "y": mon["vlc_y"],
+            "width": mon["vlc_width"],
+            "height": mon["vlc_height"],
+            "monitor": monitor,
         }
-        self.playlist_thread = threading.Thread(
+        mon["playlist_thread"] = threading.Thread(
             target=vlc_playlist.run,
-            args=(self.playlist_path,),
+            args=(mon["playlist_path"],),
             kwargs=kwargs,
             daemon=True,
         )
-        self.playlist_thread.start()
-        vlc_playlist.set_gui_images(self.gui_images)
+        mon["playlist_thread"].start()
+        vlc_playlist.set_gui_images(self.gui_images, monitor)
 
 
-    def stop_vlc(self) -> None:
-        if self.vlc_thread and self.vlc_thread.is_alive():
-            vlc_embed.stop()
-            self.vlc_thread.join(timeout=1)
-            self.vlc_thread = None
-        if self.playlist_thread and self.playlist_thread.is_alive():
-            vlc_playlist.stop()
-            self.playlist_thread.join(timeout=1)
-            self.playlist_thread = None
-        if self.playlist_path:
-            try:
-                os.unlink(self.playlist_path)
-            except FileNotFoundError:
-                pass
-            self.playlist_path = None
-        vlc_embed.set_gui_images([])
-        vlc_playlist.set_gui_images([])
+    def stop_vlc(self, monitor: Optional[int] = None) -> None:
+        mons = [monitor] if monitor else list(self.monitors.keys())
+        for m in mons:
+            mon = self.monitors.get(m)
+            if not mon:
+                continue
+            if mon["vlc_thread"] and mon["vlc_thread"].is_alive():
+                vlc_embed.stop(m)
+                mon["vlc_thread"].join(timeout=1)
+                mon["vlc_thread"] = None
+            if mon["playlist_thread"] and mon["playlist_thread"].is_alive():
+                vlc_playlist.stop(m)
+                mon["playlist_thread"].join(timeout=1)
+                mon["playlist_thread"] = None
+            if mon["playlist_path"]:
+                try:
+                    os.unlink(mon["playlist_path"])
+                except FileNotFoundError:
+                    pass
+                mon["playlist_path"] = None
+            vlc_embed.set_gui_images([], m)
+            vlc_playlist.set_gui_images([], m)
 
     def run(self):
         loop = asyncio.new_event_loop()
@@ -314,23 +341,33 @@ class WSClient:
                     res = data.get("Resolution") or data.get("resolution")
                     orient = data.get("Orientation")
                     if res or orient is not None:
-                        display_config.set_display_config(res, orient)
+                        display_config.set_display_config(res, orient, monitor=1)
+                    mon1 = data.get("Monitor1") or {}
+                    mon2 = data.get("Monitor2") or {}
+                    for idx, mon in ((1, mon1), (2, mon2)):
+                        if not isinstance(mon, dict):
+                            continue
+                        r = mon.get("Resolution") or mon.get("resolution")
+                        o = mon.get("Orientation")
+                        if r or o is not None:
+                            display_config.set_display_config(r, o, monitor=idx)
+                        try:
+                            if mon.get("VlcX") is not None:
+                                self.monitors[idx]["vlc_x"] = int(float(mon.get("VlcX")))
+                            if mon.get("VlcY") is not None:
+                                self.monitors[idx]["vlc_y"] = int(float(mon.get("VlcY")))
+                            if mon.get("VlcWidth") is not None:
+                                self.monitors[idx]["vlc_width"] = int(float(mon.get("VlcWidth")))
+                            if mon.get("VlcHeight") is not None:
+                                self.monitors[idx]["vlc_height"] = int(float(mon.get("VlcHeight")))
+                        except Exception:
+                            pass
                     images = data.get("GuiImages")
                     if isinstance(images, list):
                         self.gui_images = list(images)
-                        vlc_embed.set_gui_images(self.gui_images)
-                        vlc_playlist.set_gui_images(self.gui_images)
-                    try:
-                        if data.get("VlcX") is not None:
-                            self.vlc_x = int(float(data.get("VlcX")))
-                        if data.get("VlcY") is not None:
-                            self.vlc_y = int(float(data.get("VlcY")))
-                        if data.get("VlcWidth") is not None:
-                            self.vlc_width = int(float(data.get("VlcWidth")))
-                        if data.get("VlcHeight") is not None:
-                            self.vlc_height = int(float(data.get("VlcHeight")))
-                    except Exception:
-                        pass
+                        for idx in (1, 2):
+                            vlc_embed.set_gui_images(self.gui_images, idx)
+                            vlc_playlist.set_gui_images(self.gui_images, idx)
                     self.device_enabled = enabled
                     if not self.device_enabled:
                         self.update_status("사용안함")
@@ -345,7 +382,8 @@ class WSClient:
                         await self.update_schedules(start_scheduler=playmode != 2)
                         if playmode in {1, 2}:
                             url = data.get("StreamURL") or data.get("url")
-                            self.start_vlc(url)
+                            for idx in (1, 2):
+                                self.start_vlc(url, monitor=idx)
                         else:
                             self.stop_vlc()
                 elif isinstance(data, dict) and data.get("type") == "test-broadcast":
@@ -360,21 +398,19 @@ class WSClient:
                         asyncio.create_task(self.play_audio_url(url, volume))
                 elif isinstance(data, dict) and data.get("type") == "play-media":
                     mid = data.get("media_id")
-                    if mid is not None and self.playlist_items:
-                        try:
-                            mid_str = str(mid)
-                            idx = next(
-                                i for i, it in enumerate(self.playlist_items)
-                                if str(it.get("MediaID") or it.get("media_id") or it.get("id")) == mid_str
-                            )
-                            self.start_vlc_playlist(self.playlist_items, start_index=idx)
-                        except StopIteration:
-                            pass
+                    if mid is not None:
+                        mid_str = str(mid)
+                        for m_idx, mon in self.monitors.items():
+                            items = mon.get("playlist_items", [])
+                            for i, it in enumerate(items):
+                                if str(it.get("MediaID") or it.get("media_id") or it.get("id")) == mid_str:
+                                    self.start_vlc_playlist(items, start_index=i, monitor=m_idx)
+                                    break
                 elif isinstance(data, dict) and data.get("type") == "playlist":
                     items = data.get("items")
                     if isinstance(items, list):
                         new_items = list(items)
-
+                        
                         def item_id(it: dict) -> str:
                             return str(
                                 it.get("MediaID")
@@ -391,24 +427,28 @@ class WSClient:
                                 return str(it.get("volume"))
                             return ""
 
-                        old = self.playlist_items
-
-                        same_order = (
-                            len(old) == len(new_items)
-                            and all(item_id(o) == item_id(n) for o, n in zip(old, new_items))
-                        )
-                        same_volume = (
-                            same_order
-                            and all(item_vol(o) == item_vol(n) for o, n in zip(old, new_items))
-                        )
-
-                        if same_order and same_volume:
-                            # No changes
-                            continue
-
-                        # Update playlist and restart VLC
                         self.playlist_items = new_items
-                        self.start_vlc_playlist(self.playlist_items)
+                        by_monitor = {1: [], 2: []}
+                        for it in new_items:
+                            m = int(it.get("Monitor", 1))
+                            if m not in by_monitor:
+                                m = 1
+                            by_monitor[m].append(it)
+                        for m_idx in (1, 2):
+                            new_list = by_monitor[m_idx]
+                            old = self.monitors[m_idx]["playlist_items"]
+                            same_order = (
+                                len(old) == len(new_list)
+                                and all(item_id(o) == item_id(n) for o, n in zip(old, new_list))
+                            )
+                            same_volume = (
+                                same_order
+                                and all(item_vol(o) == item_vol(n) for o, n in zip(old, new_list))
+                            )
+                            if same_order and same_volume:
+                                continue
+                            self.monitors[m_idx]["playlist_items"] = new_list
+                            self.start_vlc_playlist(new_list, monitor=m_idx)
                 elif isinstance(data, dict) and data.get("type") == "refresh-schedules":
                     await self.update_schedules(start_scheduler=self.playmode != 2)
                 else:

--- a/vlc_embed.py
+++ b/vlc_embed.py
@@ -88,11 +88,11 @@ def _attach_handle(player: vlc.MediaPlayer, handle: int) -> None:
         player.set_xwindow(handle)
 
 
-_root: Optional[tk.Tk] = None
-_player: Optional[vlc.MediaPlayer] = None
-_gui_images: List[Dict[str, any]] = []
-_gui_labels: List[Dict[str, any]] = []
-_gui_windows: List[tk.Toplevel] = []
+_roots: Dict[int, tk.Tk] = {}
+_players: Dict[int, vlc.MediaPlayer] = {}
+_gui_images: Dict[int, List[Dict[str, any]]] = {}
+_gui_labels: Dict[int, List[Dict[str, any]]] = {}
+_gui_windows: Dict[int, List[tk.Toplevel]] = {}
 
 
 def fix_media_url(url: str) -> str:
@@ -105,7 +105,12 @@ def fix_media_url(url: str) -> str:
     return url
 
 
-def _load_image_frames(url: str, width: Optional[int], height: Optional[int]) -> tuple[List, List]:
+def _load_image_frames(
+    url: str,
+    width: Optional[int],
+    height: Optional[int],
+    root: tk.Tk,
+) -> tuple[List, List]:
     """Return a list of PhotoImage frames and their durations."""
     try:
         if urlparse(url).scheme in {"http", "https"}:
@@ -124,38 +129,39 @@ def _load_image_frames(url: str, width: Optional[int], height: Optional[int]) ->
         if width and height:
             frame = frame.resize((int(width), int(height)), Image.LANCZOS)
         frame = frame.convert("RGBA")
-        frames.append(ImageTk.PhotoImage(frame, master=_root))
+        frames.append(ImageTk.PhotoImage(frame, master=root))
         delays.append(int(frame.info.get("duration", 100)))
     if not frames:
         if width and height:
             img = img.resize((int(width), int(height)), Image.LANCZOS)
-        frames.append(ImageTk.PhotoImage(img.convert("RGBA"), master=_root))
+        frames.append(ImageTk.PhotoImage(img.convert("RGBA"), master=root))
         delays.append(int(img.info.get("duration", 100)))
     return frames, delays
 
 
-def _clear_gui_images() -> None:
-    for item in _gui_labels:
+def _clear_gui_images(monitor: int) -> None:
+    for item in _gui_labels.get(monitor, []):
         try:
             item["label"].destroy()
         except Exception:
             pass
-    _gui_labels.clear()
-    for win in _gui_windows:
+    _gui_labels[monitor] = []
+    for win in _gui_windows.get(monitor, []):
         try:
             win.destroy()
         except Exception:
             pass
-    _gui_windows.clear()
+    _gui_windows[monitor] = []
 
 
-def _apply_gui_images() -> None:
-    if _root is None or not _root.winfo_exists():
+def _apply_gui_images(monitor: int) -> None:
+    root = _roots.get(monitor)
+    if root is None or not root.winfo_exists():
         return
-    _clear_gui_images()
-    base_x = _root.winfo_rootx()
-    base_y = _root.winfo_rooty()
-    for info in _gui_images:
+    _clear_gui_images(monitor)
+    base_x = root.winfo_rootx()
+    base_y = root.winfo_rooty()
+    for info in _gui_images.get(monitor, []):
         url = str(info.get("ImageUrl") or info.get("url") or "")
         if url:
             url = fix_media_url(url)
@@ -164,7 +170,12 @@ def _apply_gui_images() -> None:
         w = info.get("Width")
         h = info.get("Height")
         try:
-            frames, delays = _load_image_frames(url, int(float(w)) if w else None, int(float(h)) if h else None)
+            frames, delays = _load_image_frames(
+                url,
+                int(float(w)) if w else None,
+                int(float(h)) if h else None,
+                root,
+            )
         except Exception as e:  # noqa: BLE001
             print(f"Failed to load GUI image {url}: {e}")
             continue
@@ -178,7 +189,7 @@ def _apply_gui_images() -> None:
         width = int(float(w)) if w else frames[0].width()
         height = int(float(h)) if h else frames[0].height()
 
-        top = tk.Toplevel(_root)
+        top = tk.Toplevel(root)
         top.overrideredirect(True)
         top.attributes("-topmost", True)
         trans = "#010203"
@@ -193,8 +204,8 @@ def _apply_gui_images() -> None:
         label.pack(fill=tk.BOTH, expand=True)
 
         entry = {"label": label, "frames": frames, "delays": delays}
-        _gui_labels.append(entry)
-        _gui_windows.append(top)
+        _gui_labels.setdefault(monitor, []).append(entry)
+        _gui_windows.setdefault(monitor, []).append(top)
 
         if len(frames) > 1:
             def animate(idx: int = 0, lbl: tk.Label = label, frs=frames, durs=delays):
@@ -206,12 +217,12 @@ def _apply_gui_images() -> None:
             label.after(delays[0], animate, 1, label, frames, delays)
 
 
-def set_gui_images(images: List[Dict[str, any]]) -> None:
-    """Update GUI overlay images."""
-    global _gui_images
-    _gui_images = list(images) if images else []
-    if _root is not None:
-        _root.after(0, _apply_gui_images)
+def set_gui_images(images: List[Dict[str, any]], monitor: int = 1) -> None:
+    """Update GUI overlay images for the given monitor."""
+    _gui_images[monitor] = list(images) if images else []
+    root = _roots.get(monitor)
+    if root is not None:
+        root.after(0, _apply_gui_images, monitor)
 
 
 def run(
@@ -221,6 +232,7 @@ def run(
     y: Optional[int] = None,
     width: Optional[int] = None,
     height: Optional[int] = None,
+    monitor: int = 1,
 ) -> None:
     """Play ``url`` in a fullscreen window with an embedded player.
 
@@ -228,9 +240,9 @@ def run(
     fullscreen window and ``width``/``height`` control its size.  When no
     geometry is provided the player fills the entire screen.
     """
-    global _root, _player
+    global _roots, _players
     root = tk.Tk()
-    _root = root
+    _roots[monitor] = root
     root.attributes("-fullscreen", True)
     root.configure(background="black")
     frame = tk.Frame(root, background="black")
@@ -248,7 +260,7 @@ def run(
     # Disable direct Xlib usage to avoid threading issues on some platforms
     instance = vlc.Instance("--no-xlib")
     player = instance.media_player_new()
-    _player = player
+    _players[monitor] = player
     def on_progress(done: int, total: int, speed: float, elapsed: float, err: Optional[Exception]) -> None:
         if err is not None:
             progress_label.place_forget()
@@ -286,33 +298,34 @@ def run(
     _attach_handle(player, handle)
 
     player.play()
-    _apply_gui_images()
-    root.protocol("WM_DELETE_WINDOW", lambda: stop())
+    _apply_gui_images(monitor)
+    root.protocol("WM_DELETE_WINDOW", lambda: stop(monitor))
     root.mainloop()
 
 
-def stop() -> None:
-    """Stop playback and close the window if running."""
-    global _root, _player, _gui_images
-    if _player is not None:
+def stop(monitor: int = 1) -> None:
+    """Stop playback and close the window for ``monitor`` if running."""
+    player = _players.get(monitor)
+    if player is not None:
         try:
-            _player.stop()
+            player.stop()
         except Exception:
             pass
-        _player = None
-    if _root is not None:
+        _players.pop(monitor, None)
+    root = _roots.get(monitor)
+    if root is not None:
         try:
-            _root.after(0, _root.destroy)
+            root.after(0, root.destroy)
         except Exception:
             pass
-        _root = None
-    _clear_gui_images()
-    _gui_images = []
+        _roots.pop(monitor, None)
+    _clear_gui_images(monitor)
+    _gui_images.pop(monitor, None)
 
 
 # Backwards compatibility
-def play_media(url: str) -> None:
-    run(url)
+def play_media(url: str, monitor: int = 1) -> None:
+    run(url, monitor=monitor)
 
 
 if __name__ == '__main__':

--- a/vlc_playlist.py
+++ b/vlc_playlist.py
@@ -31,20 +31,25 @@ RUN_DIR = pathlib.Path(sys.argv[0]).resolve().parent
 CACHE_DIR = RUN_DIR / "cache"
 
 
-_root: Optional[tk.Tk] = None
-_player: Optional[vlc.MediaPlayer] = None
-_after_id: Optional[str] = None
-_check_id: Optional[str] = None
-_playlist_path: Optional[str] = None
-_items: Optional[list] = None
-_idx: int = 0
-_last_mtime: float = 0.0
-_gui_images: List[Dict[str, any]] = []
-_gui_labels: List[Dict[str, any]] = []
-_gui_windows: List[tk.Toplevel] = []
+_roots: Dict[int, tk.Tk] = {}
+_players: Dict[int, vlc.MediaPlayer] = {}
+_after_ids: Dict[int, str] = {}
+_check_ids: Dict[int, str] = {}
+_playlist_paths: Dict[int, str] = {}
+_items_map: Dict[int, list] = {}
+_idx_map: Dict[int, int] = {}
+_last_mtimes: Dict[int, float] = {}
+_gui_images: Dict[int, List[Dict[str, any]]] = {}
+_gui_labels: Dict[int, List[Dict[str, any]]] = {}
+_gui_windows: Dict[int, List[tk.Toplevel]] = {}
 
 
-def _load_image_frames(url: str, width: Optional[int], height: Optional[int]) -> tuple[List, List]:
+def _load_image_frames(
+    url: str,
+    width: Optional[int],
+    height: Optional[int],
+    root: tk.Tk,
+) -> tuple[List, List]:
     try:
         if urlparse(url).scheme in {"http", "https"}:
             r = httpx.get(url, timeout=30)
@@ -62,38 +67,39 @@ def _load_image_frames(url: str, width: Optional[int], height: Optional[int]) ->
         if width and height:
             frame = frame.resize((int(width), int(height)), Image.LANCZOS)
         frame = frame.convert("RGBA")
-        frames.append(ImageTk.PhotoImage(frame, master=_root))
+        frames.append(ImageTk.PhotoImage(frame, master=root))
         delays.append(int(frame.info.get("duration", 100)))
     if not frames:
         if width and height:
             img = img.resize((int(width), int(height)), Image.LANCZOS)
-        frames.append(ImageTk.PhotoImage(img.convert("RGBA"), master=_root))
+        frames.append(ImageTk.PhotoImage(img.convert("RGBA"), master=root))
         delays.append(int(img.info.get("duration", 100)))
     return frames, delays
 
 
-def _clear_gui_images() -> None:
-    for item in _gui_labels:
+def _clear_gui_images(monitor: int) -> None:
+    for item in _gui_labels.get(monitor, []):
         try:
             item["label"].destroy()
         except Exception:
             pass
-    _gui_labels.clear()
-    for win in _gui_windows:
+    _gui_labels[monitor] = []
+    for win in _gui_windows.get(monitor, []):
         try:
             win.destroy()
         except Exception:
             pass
-    _gui_windows.clear()
+    _gui_windows[monitor] = []
 
 
-def _apply_gui_images() -> None:
-    if _root is None or not _root.winfo_exists():
+def _apply_gui_images(monitor: int) -> None:
+    root = _roots.get(monitor)
+    if root is None or not root.winfo_exists():
         return
-    _clear_gui_images()
-    base_x = _root.winfo_rootx()
-    base_y = _root.winfo_rooty()
-    for info in _gui_images:
+    _clear_gui_images(monitor)
+    base_x = root.winfo_rootx()
+    base_y = root.winfo_rooty()
+    for info in _gui_images.get(monitor, []):
         url = str(info.get("ImageUrl") or info.get("url") or "")
         if url:
             url = fix_media_url(url)
@@ -102,7 +108,12 @@ def _apply_gui_images() -> None:
         w = info.get("Width")
         h = info.get("Height")
         try:
-            frames, delays = _load_image_frames(url, int(float(w)) if w else None, int(float(h)) if h else None)
+            frames, delays = _load_image_frames(
+                url,
+                int(float(w)) if w else None,
+                int(float(h)) if h else None,
+                root,
+            )
         except Exception as e:  # noqa: BLE001
             print(f"Failed to load GUI image {url}: {e}")
             continue
@@ -116,7 +127,7 @@ def _apply_gui_images() -> None:
         width = int(float(w)) if w else frames[0].width()
         height = int(float(h)) if h else frames[0].height()
 
-        top = tk.Toplevel(_root)
+        top = tk.Toplevel(root)
         top.overrideredirect(True)
         top.attributes("-topmost", True)
         trans = "#010203"
@@ -131,8 +142,8 @@ def _apply_gui_images() -> None:
         label.pack(fill=tk.BOTH, expand=True)
 
         entry = {"label": label, "frames": frames, "delays": delays}
-        _gui_labels.append(entry)
-        _gui_windows.append(top)
+        _gui_labels.setdefault(monitor, []).append(entry)
+        _gui_windows.setdefault(monitor, []).append(top)
 
         if len(frames) > 1:
             def animate(idx: int = 0, lbl: tk.Label = label, frs=frames, durs=delays):
@@ -144,11 +155,11 @@ def _apply_gui_images() -> None:
             label.after(delays[0], animate, 1, label, frames, delays)
 
 
-def set_gui_images(images: List[Dict[str, any]]) -> None:
-    global _gui_images
-    _gui_images = list(images) if images else []
-    if _root is not None:
-        _root.after(0, _apply_gui_images)
+def set_gui_images(images: List[Dict[str, any]], monitor: int = 1) -> None:
+    _gui_images[monitor] = list(images) if images else []
+    root = _roots.get(monitor)
+    if root is not None:
+        root.after(0, _apply_gui_images, monitor)
 
 
 def cache_media(url: str, progress_cb=None) -> str:
@@ -240,6 +251,7 @@ def run(
     y: Optional[int] = None,
     width: Optional[int] = None,
     height: Optional[int] = None,
+    monitor: int = 1,
 ) -> None:
     """Play playlist defined in ``path`` and reload when it changes.
 
@@ -265,12 +277,12 @@ def run(
             print(f"Failed to load playlist: {e}")
             return [], 0
 
-    global _root, _player, _after_id, _check_id, _playlist_path, _items, _idx, _last_mtime
+    global _roots, _players, _after_ids, _check_ids, _playlist_paths, _items_map, _idx_map, _last_mtimes
 
-    _playlist_path = path
+    _playlist_paths[monitor] = path
 
     root = tk.Tk()
-    _root = root
+    _roots[monitor] = root
     root.attributes("-fullscreen", True)
     root.configure(background="black")
     frame = tk.Frame(root, background="black")
@@ -288,17 +300,17 @@ def run(
     # Disable direct Xlib usage to avoid threading issues on some platforms
     instance = vlc.Instance("--no-xlib")
     player = instance.media_player_new()
-    _player = player
+    _players[monitor] = player
     root.update_idletasks()
     _attach_handle(player, frame.winfo_id())
-    _apply_gui_images()
+    _apply_gui_images(monitor)
 
     items, idx = load()
-    _items = items
+    _items_map[monitor] = items
     idx = max(0, int(idx))
-    _idx = idx
+    _idx_map[monitor] = idx
     last_mtime = os.path.getmtime(path) if os.path.exists(path) else 0.0
-    _last_mtime = last_mtime
+    _last_mtimes[monitor] = last_mtime
     after_id = None
 
     def play_next() -> None:
@@ -312,7 +324,7 @@ def run(
             idx = 0
         item = items[idx]
         idx += 1
-        _idx = idx
+        _idx_map[monitor] = idx
 
         url = item.get("MediaUrl") or item.get("url")
         if url:
@@ -375,7 +387,7 @@ def run(
         if is_image(item):
             dur = int(item.get("DurationSeconds") or DEFAULT_IMAGE_DURATION)
             after_id = root.after(dur * 1000, play_next)
-            _after_id = after_id
+            _after_ids[monitor] = after_id
         else:
             def on_end(event):
                 player.event_manager().event_detach(vlc.EventType.MediaPlayerEndReached)
@@ -390,62 +402,65 @@ def run(
         try:
             mtime = os.path.getmtime(path)
         except FileNotFoundError:
-            _check_id = root.after(1000, check_update)
+            _check_ids[monitor] = root.after(1000, check_update)
             return
         if mtime != last_mtime:
             last_mtime = mtime
             new_items, new_idx = load()
             if new_items:
                 items = new_items
-                _items = items
+                _items_map[monitor] = items
                 idx = max(0, int(new_idx))
-                _idx = idx
+                _idx_map[monitor] = idx
                 player.stop()
                 play_next()
-        _check_id = root.after(1000, check_update)
+        _check_ids[monitor] = root.after(1000, check_update)
 
     play_next()
-    _check_id = root.after(1000, check_update)
+    _check_ids[monitor] = root.after(1000, check_update)
 
-    root.protocol("WM_DELETE_WINDOW", lambda: stop())
+    root.protocol("WM_DELETE_WINDOW", lambda: stop(monitor))
     root.mainloop()
 
 
-def stop() -> None:
-    """Stop playback and close the window if running."""
-    global _root, _player, _after_id, _check_id, _gui_images
-    if _root is None:
+def stop(monitor: int = 1) -> None:
+    """Stop playback and close the window for ``monitor`` if running."""
+    root = _roots.get(monitor)
+    if root is None:
         return
-    if _after_id is not None:
+    after_id = _after_ids.get(monitor)
+    if after_id is not None:
         try:
-            _root.after_cancel(_after_id)
+            root.after_cancel(after_id)
         except Exception:
             pass
-        _after_id = None
-    if _check_id is not None:
+        _after_ids.pop(monitor, None)
+    check_id = _check_ids.get(monitor)
+    if check_id is not None:
         try:
-            _root.after_cancel(_check_id)
+            root.after_cancel(check_id)
         except Exception:
             pass
-        _check_id = None
-    if _player is not None:
+        _check_ids.pop(monitor, None)
+    player = _players.get(monitor)
+    if player is not None:
         try:
-            _player.stop()
+            player.stop()
         except Exception:
             pass
-        _player = None
+        _players.pop(monitor, None)
     try:
-        _root.after(0, _root.destroy)
+        root.after(0, root.destroy)
     except Exception:
         pass
-    _root = None
-    _clear_gui_images()
-    _gui_images = []
+    _roots.pop(monitor, None)
+    _clear_gui_images(monitor)
+    _gui_images.pop(monitor, None)
 
 
-def play_playlist(path: str) -> None:
+def play_playlist(path: str, monitor: int = 1) -> None:
     """Backward compatible wrapper for ``run``."""
-    run(path)
+    run(path, monitor=monitor)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- support configuring and controlling two monitors
- extend display configuration APIs to accept monitor index
- allow VLC embed/player modules to manage multiple windows
- update websocket client to split playlists by monitor

## Testing
- `python -m py_compile gui_client.py vlc_embed.py vlc_playlist.py display_config.py`

------
https://chatgpt.com/codex/tasks/task_e_6883411913308324b8629b7008a99ff4