### PR TITLE
Add overlay support for videos and web URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,10 +51,11 @@ Config messages may also include `Resolution` (e.g. `"1920x1080"`) and
 `Orientation` (0-4) fields.  When present, the client attempts to update the
 system's display settings accordingly on Windows and Linux (including
 Raspberry Pi and Orange Pi) using platform specific commands.
-Additionally a `GuiImages` array may be provided to overlay PNG or GIF images
-on top of the VLC window.  Each entry should contain `ImageUrl`, `X`, `Y`,
-`Width` and `Height` values.  GIF images animate and transparency is
-respected.
+Additionally a `GuiImages` array may be provided to overlay elements on top of
+the VLC window.  Each entry should contain `ImageUrl`, `X`, `Y`, `Width`,
+`Height`, `GuiKind` and `Monitor` values.  `GuiKind` can be `image`, `video` or
+`url` and determines whether an image, video or embedded web view is shown on
+the specified monitor.  GIF images animate and transparency is respected.
 
 The client also handles playlist messages. When a playlist is received it
 is passed to `vlc_playlist.py` for fullscreen playback. A subsequent

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ httpx[http2]
 pystray
 pillow
 python-vlc
+tkinterweb

--- a/vlc_embed.py
+++ b/vlc_embed.py
@@ -91,8 +91,7 @@ def _attach_handle(player: vlc.MediaPlayer, handle: int) -> None:
 _roots: Dict[int, tk.Tk] = {}
 _players: Dict[int, vlc.MediaPlayer] = {}
 _gui_images: Dict[int, List[Dict[str, any]]] = {}
-_gui_labels: Dict[int, List[Dict[str, any]]] = {}
-_gui_windows: Dict[int, List[tk.Toplevel]] = {}
+_gui_entries: Dict[int, List[Dict[str, any]]] = {}
 
 
 def fix_media_url(url: str) -> str:
@@ -139,55 +138,58 @@ def _load_image_frames(
     return frames, delays
 
 
-def _clear_gui_images(monitor: int) -> None:
-    for item in _gui_labels.get(monitor, []):
-        try:
-            item["label"].destroy()
-        except Exception:
-            pass
-    _gui_labels[monitor] = []
-    for win in _gui_windows.get(monitor, []):
-        try:
-            win.destroy()
-        except Exception:
-            pass
-    _gui_windows[monitor] = []
+def _clear_gui_elements(monitor: int) -> None:
+    for entry in _gui_entries.get(monitor, []):
+        player = entry.get("player")
+        if player is not None:
+            try:
+                player.stop()
+            except Exception:
+                pass
+        label = entry.get("label")
+        if label is not None:
+            try:
+                label.destroy()
+            except Exception:
+                pass
+        win = entry.get("window")
+        if win is not None:
+            try:
+                win.destroy()
+            except Exception:
+                pass
+    _gui_entries[monitor] = []
 
 
 def _apply_gui_images(monitor: int) -> None:
     root = _roots.get(monitor)
     if root is None or not root.winfo_exists():
         return
-    _clear_gui_images(monitor)
+    _clear_gui_elements(monitor)
     base_x = root.winfo_rootx()
     base_y = root.winfo_rooty()
     for info in _gui_images.get(monitor, []):
-        url = str(info.get("ImageUrl") or info.get("url") or "")
+        url = str(
+            info.get("ImageUrl")
+            or info.get("VideoUrl")
+            or info.get("Url")
+            or info.get("url")
+            or ""
+        )
         if url:
             url = fix_media_url(url)
         if not url:
             continue
+        kind = str(info.get("GuiKind") or info.get("kind") or "image").lower()
         w = info.get("Width")
         h = info.get("Height")
-        try:
-            frames, delays = _load_image_frames(
-                url,
-                int(float(w)) if w else None,
-                int(float(h)) if h else None,
-                root,
-            )
-        except Exception as e:  # noqa: BLE001
-            print(f"Failed to load GUI image {url}: {e}")
-            continue
-        if not frames:
-            continue
         try:
             x = int(float(info.get("X", 0)))
             y = int(float(info.get("Y", 0)))
         except Exception:
             x = y = 0
-        width = int(float(w)) if w else frames[0].width()
-        height = int(float(h)) if h else frames[0].height()
+        width = int(float(w)) if w else None
+        height = int(float(h)) if h else None
 
         top = tk.Toplevel(root)
         top.overrideredirect(True)
@@ -198,27 +200,73 @@ def _apply_gui_images(monitor: int) -> None:
         except Exception:
             pass
         top.configure(bg=trans)
-        top.geometry(f"{width}x{height}+{base_x + x}+{base_y + y}")
+        if width and height:
+            top.geometry(f"{width}x{height}+{base_x + x}+{base_y + y}")
+        else:
+            top.geometry(f"+{base_x + x}+{base_y + y}")
 
-        label = tk.Label(top, image=frames[0], bd=0, highlightthickness=0, bg=trans)
-        label.pack(fill=tk.BOTH, expand=True)
+        entry = {"window": top, "kind": kind}
 
-        entry = {"label": label, "frames": frames, "delays": delays}
-        _gui_labels.setdefault(monitor, []).append(entry)
-        _gui_windows.setdefault(monitor, []).append(top)
+        if kind == "image":
+            try:
+                frames, delays = _load_image_frames(
+                    url,
+                    width,
+                    height,
+                    root,
+                )
+            except Exception as e:  # noqa: BLE001
+                print(f"Failed to load GUI image {url}: {e}")
+                top.destroy()
+                continue
+            if not frames:
+                top.destroy()
+                continue
+            label = tk.Label(top, image=frames[0], bd=0, highlightthickness=0, bg=trans)
+            label.pack(fill=tk.BOTH, expand=True)
+            entry.update({"label": label, "frames": frames, "delays": delays})
+            if len(frames) > 1:
+                def animate(idx: int = 0, lbl: tk.Label = label, frs=frames, durs=delays):
+                    if not lbl.winfo_exists():
+                        return
+                    lbl.configure(image=frs[idx])
+                    lbl.after(durs[idx], animate, (idx + 1) % len(frs), lbl, frs, durs)
 
-        if len(frames) > 1:
-            def animate(idx: int = 0, lbl: tk.Label = label, frs=frames, durs=delays):
-                if not lbl.winfo_exists():
-                    return
-                lbl.configure(image=frs[idx])
-                lbl.after(durs[idx], animate, (idx + 1) % len(frs), lbl, frs, durs)
+                label.after(delays[0], animate, 1, label, frames, delays)
+        elif kind == "video":
+            frame = tk.Frame(top, background="black")
+            if width and height:
+                frame.place(x=0, y=0, width=int(width), height=int(height))
+            else:
+                frame.pack(fill=tk.BOTH, expand=True)
+            instance = vlc.Instance("--no-xlib")
+            player = instance.media_player_new()
+            _attach_handle(player, frame.winfo_id())
+            media = instance.media_new(url)
+            player.set_media(media)
+            player.play()
+            entry.update({"player": player})
+        elif kind == "url":
+            try:
+                from tkinterweb import HtmlFrame
+                web = HtmlFrame(top)
+                web.load_website(url)
+                web.pack(fill=tk.BOTH, expand=True)
+                entry.update({"web": web})
+            except Exception:
+                import webbrowser
+                webbrowser.open(url)
+                top.destroy()
+                continue
+        else:
+            top.destroy()
+            continue
 
-            label.after(delays[0], animate, 1, label, frames, delays)
+        _gui_entries.setdefault(monitor, []).append(entry)
 
 
 def set_gui_images(images: List[Dict[str, any]], monitor: int = 1) -> None:
-    """Update GUI overlay images for the given monitor."""
+    """Update overlay elements (images, videos, web views) for ``monitor``."""
     _gui_images[monitor] = list(images) if images else []
     root = _roots.get(monitor)
     if root is not None:
@@ -319,7 +367,7 @@ def stop(monitor: int = 1) -> None:
         except Exception:
             pass
         _roots.pop(monitor, None)
-    _clear_gui_images(monitor)
+    _clear_gui_elements(monitor)
     _gui_images.pop(monitor, None)
 
 

--- a/vlc_playlist.py
+++ b/vlc_playlist.py
@@ -40,8 +40,7 @@ _items_map: Dict[int, list] = {}
 _idx_map: Dict[int, int] = {}
 _last_mtimes: Dict[int, float] = {}
 _gui_images: Dict[int, List[Dict[str, any]]] = {}
-_gui_labels: Dict[int, List[Dict[str, any]]] = {}
-_gui_windows: Dict[int, List[tk.Toplevel]] = {}
+_gui_entries: Dict[int, List[Dict[str, any]]] = {}
 
 
 def _load_image_frames(
@@ -77,55 +76,58 @@ def _load_image_frames(
     return frames, delays
 
 
-def _clear_gui_images(monitor: int) -> None:
-    for item in _gui_labels.get(monitor, []):
-        try:
-            item["label"].destroy()
-        except Exception:
-            pass
-    _gui_labels[monitor] = []
-    for win in _gui_windows.get(monitor, []):
-        try:
-            win.destroy()
-        except Exception:
-            pass
-    _gui_windows[monitor] = []
+def _clear_gui_elements(monitor: int) -> None:
+    for entry in _gui_entries.get(monitor, []):
+        player = entry.get("player")
+        if player is not None:
+            try:
+                player.stop()
+            except Exception:
+                pass
+        label = entry.get("label")
+        if label is not None:
+            try:
+                label.destroy()
+            except Exception:
+                pass
+        win = entry.get("window")
+        if win is not None:
+            try:
+                win.destroy()
+            except Exception:
+                pass
+    _gui_entries[monitor] = []
 
 
 def _apply_gui_images(monitor: int) -> None:
     root = _roots.get(monitor)
     if root is None or not root.winfo_exists():
         return
-    _clear_gui_images(monitor)
+    _clear_gui_elements(monitor)
     base_x = root.winfo_rootx()
     base_y = root.winfo_rooty()
     for info in _gui_images.get(monitor, []):
-        url = str(info.get("ImageUrl") or info.get("url") or "")
+        url = str(
+            info.get("ImageUrl")
+            or info.get("VideoUrl")
+            or info.get("Url")
+            or info.get("url")
+            or ""
+        )
         if url:
             url = fix_media_url(url)
         if not url:
             continue
+        kind = str(info.get("GuiKind") or info.get("kind") or "image").lower()
         w = info.get("Width")
         h = info.get("Height")
-        try:
-            frames, delays = _load_image_frames(
-                url,
-                int(float(w)) if w else None,
-                int(float(h)) if h else None,
-                root,
-            )
-        except Exception as e:  # noqa: BLE001
-            print(f"Failed to load GUI image {url}: {e}")
-            continue
-        if not frames:
-            continue
         try:
             x = int(float(info.get("X", 0)))
             y = int(float(info.get("Y", 0)))
         except Exception:
             x = y = 0
-        width = int(float(w)) if w else frames[0].width()
-        height = int(float(h)) if h else frames[0].height()
+        width = int(float(w)) if w else None
+        height = int(float(h)) if h else None
 
         top = tk.Toplevel(root)
         top.overrideredirect(True)
@@ -136,26 +138,73 @@ def _apply_gui_images(monitor: int) -> None:
         except Exception:
             pass
         top.configure(bg=trans)
-        top.geometry(f"{width}x{height}+{base_x + x}+{base_y + y}")
+        if width and height:
+            top.geometry(f"{width}x{height}+{base_x + x}+{base_y + y}")
+        else:
+            top.geometry(f"+{base_x + x}+{base_y + y}")
 
-        label = tk.Label(top, image=frames[0], bd=0, highlightthickness=0, bg=trans)
-        label.pack(fill=tk.BOTH, expand=True)
+        entry = {"window": top, "kind": kind}
 
-        entry = {"label": label, "frames": frames, "delays": delays}
-        _gui_labels.setdefault(monitor, []).append(entry)
-        _gui_windows.setdefault(monitor, []).append(top)
+        if kind == "image":
+            try:
+                frames, delays = _load_image_frames(
+                    url,
+                    width,
+                    height,
+                    root,
+                )
+            except Exception as e:  # noqa: BLE001
+                print(f"Failed to load GUI image {url}: {e}")
+                top.destroy()
+                continue
+            if not frames:
+                top.destroy()
+                continue
+            label = tk.Label(top, image=frames[0], bd=0, highlightthickness=0, bg=trans)
+            label.pack(fill=tk.BOTH, expand=True)
+            entry.update({"label": label, "frames": frames, "delays": delays})
+            if len(frames) > 1:
+                def animate(idx: int = 0, lbl: tk.Label = label, frs=frames, durs=delays):
+                    if not lbl.winfo_exists():
+                        return
+                    lbl.configure(image=frs[idx])
+                    lbl.after(durs[idx], animate, (idx + 1) % len(frs), lbl, frs, durs)
 
-        if len(frames) > 1:
-            def animate(idx: int = 0, lbl: tk.Label = label, frs=frames, durs=delays):
-                if not lbl.winfo_exists():
-                    return
-                lbl.configure(image=frs[idx])
-                lbl.after(durs[idx], animate, (idx + 1) % len(frs), lbl, frs, durs)
+                label.after(delays[0], animate, 1, label, frames, delays)
+        elif kind == "video":
+            frame = tk.Frame(top, background="black")
+            if width and height:
+                frame.place(x=0, y=0, width=int(width), height=int(height))
+            else:
+                frame.pack(fill=tk.BOTH, expand=True)
+            instance = vlc.Instance("--no-xlib")
+            player = instance.media_player_new()
+            _attach_handle(player, frame.winfo_id())
+            media = instance.media_new(url)
+            player.set_media(media)
+            player.play()
+            entry.update({"player": player})
+        elif kind == "url":
+            try:
+                from tkinterweb import HtmlFrame
+                web = HtmlFrame(top)
+                web.load_website(url)
+                web.pack(fill=tk.BOTH, expand=True)
+                entry.update({"web": web})
+            except Exception:
+                import webbrowser
+                webbrowser.open(url)
+                top.destroy()
+                continue
+        else:
+            top.destroy()
+            continue
 
-            label.after(delays[0], animate, 1, label, frames, delays)
+        _gui_entries.setdefault(monitor, []).append(entry)
 
 
 def set_gui_images(images: List[Dict[str, any]], monitor: int = 1) -> None:
+    """Update overlay elements (images, videos, web views) for ``monitor``."""
     _gui_images[monitor] = list(images) if images else []
     root = _roots.get(monitor)
     if root is not None:
@@ -454,7 +503,7 @@ def stop(monitor: int = 1) -> None:
     except Exception:
         pass
     _roots.pop(monitor, None)
-    _clear_gui_images(monitor)
+    _clear_gui_elements(monitor)
     _gui_images.pop(monitor, None)
 
 


### PR DESCRIPTION
## Summary
- support overlay elements that can be images, videos or URLs
- clear and apply GUI elements generically across monitors
- document new `GuiKind` and `Monitor` fields
- require `tkinterweb` in requirements for embedded web views

## Testing
- `python -m py_compile gui_client.py vlc_embed.py vlc_playlist.py display_config.py scheduler.py`
- `pip install -r requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_6883912df5b883248c20d0427b9d1f96