### PR TITLE
Support GuiOrder sorting for overlays

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,9 +53,11 @@ system's display settings accordingly on Windows and Linux (including
 Raspberry Pi and Orange Pi) using platform specific commands.
 Additionally a `GuiImages` array may be provided to overlay elements on top of
 the VLC window.  Each entry should contain `ImageUrl`, `X`, `Y`, `Width`,
-`Height`, `GuiKind` and `Monitor` values.  `GuiKind` can be `image`, `video` or
-`url` and determines whether an image, video or embedded web view is shown on
-the specified monitor.  GIF images animate and transparency is respected.
+`Height`, `GuiKind`, `Monitor` and optional `GuiOrder` values.  `GuiKind` can
+be `image`, `video` or `url` and determines whether an image, video or embedded
+web view is shown on the specified monitor.  `GuiOrder` starts at `0` with
+lower numbers appearing above higher ones.  GIF images animate and transparency
+is respected.
 
 The client also handles playlist messages. When a playlist is received it
 is passed to `vlc_playlist.py` for fullscreen playback. A subsequent

--- a/vlc_embed.py
+++ b/vlc_embed.py
@@ -168,7 +168,16 @@ def _apply_gui_images(monitor: int) -> None:
     _clear_gui_elements(monitor)
     base_x = root.winfo_rootx()
     base_y = root.winfo_rooty()
-    for info in _gui_images.get(monitor, []):
+    images = list(_gui_images.get(monitor, []))
+
+    def order_val(item: Dict[str, any]) -> int:
+        try:
+            return int(float(item.get("GuiOrder", 0)))
+        except Exception:
+            return 0
+
+    images.sort(key=order_val, reverse=True)
+    for info in images:
         url = str(
             info.get("ImageUrl")
             or info.get("VideoUrl")

--- a/vlc_playlist.py
+++ b/vlc_playlist.py
@@ -106,7 +106,16 @@ def _apply_gui_images(monitor: int) -> None:
     _clear_gui_elements(monitor)
     base_x = root.winfo_rootx()
     base_y = root.winfo_rooty()
-    for info in _gui_images.get(monitor, []):
+    images = list(_gui_images.get(monitor, []))
+
+    def order_val(item: Dict[str, any]) -> int:
+        try:
+            return int(float(item.get("GuiOrder", 0)))
+        except Exception:
+            return 0
+
+    images.sort(key=order_val, reverse=True)
+    for info in images:
         url = str(
             info.get("ImageUrl")
             or info.get("VideoUrl")


### PR DESCRIPTION
## Summary
- document new `GuiOrder` field for overlay elements
- sort GUI overlay elements by `GuiOrder` so lower numbers appear on top

## Testing
- `python -m py_compile vlc_embed.py vlc_playlist.py gui_client.py scheduler.py display_config.py`

------
https://chatgpt.com/codex/tasks/task_e_68839b5b9d0c8324a449ca682c6f3c14