### PR TITLE
Fix GuiOrder stacking

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,9 +53,11 @@ system's display settings accordingly on Windows and Linux (including
 Raspberry Pi and Orange Pi) using platform specific commands.
 Additionally a `GuiImages` array may be provided to overlay elements on top of
 the VLC window.  Each entry should contain `ImageUrl`, `X`, `Y`, `Width`,
-`Height`, `GuiKind` and `Monitor` values.  `GuiKind` can be `image`, `video` or
-`url` and determines whether an image, video or embedded web view is shown on
-the specified monitor.  GIF images animate and transparency is respected.
+`Height`, `GuiKind`, `GuiOrder` and `Monitor` values.  `GuiKind` can be
+`image`, `video` or `url` and determines whether an image, video or embedded
+web view is shown on the specified monitor.  `GuiOrder` starts at `0` and lower
+numbers are placed above higher values, allowing precise control of the
+stacking order.  GIF images animate and transparency is respected.
 
 The client also handles playlist messages. When a playlist is received it
 is passed to `vlc_playlist.py` for fullscreen playback. A subsequent

--- a/vlc_embed.py
+++ b/vlc_embed.py
@@ -168,7 +168,12 @@ def _apply_gui_images(monitor: int) -> None:
     _clear_gui_elements(monitor)
     base_x = root.winfo_rootx()
     base_y = root.winfo_rooty()
-    for info in _gui_images.get(monitor, []):
+    # Create windows from lowest to highest order so ``GuiOrder`` 0 is on top
+    images = sorted(
+        _gui_images.get(monitor, []),
+        key=lambda i: int(i.get("GuiOrder", 0)),
+    )
+    for info in images:
         url = str(
             info.get("ImageUrl")
             or info.get("VideoUrl")

--- a/vlc_playlist.py
+++ b/vlc_playlist.py
@@ -106,7 +106,12 @@ def _apply_gui_images(monitor: int) -> None:
     _clear_gui_elements(monitor)
     base_x = root.winfo_rootx()
     base_y = root.winfo_rooty()
-    for info in _gui_images.get(monitor, []):
+    # Process lowest orders first so smaller numbers remain on top
+    images = sorted(
+        _gui_images.get(monitor, []),
+        key=lambda i: int(i.get("GuiOrder", 0)),
+    )
+    for info in images:
         url = str(
             info.get("ImageUrl")
             or info.get("VideoUrl")


### PR DESCRIPTION
## Summary
- keep GuiOrder 0 on top by sorting overlays from lowest to highest

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile vlc_embed.py vlc_playlist.py gui_client.py display_config.py scheduler.py`


------
https://chatgpt.com/codex/tasks/task_e_68839b5b9d0c8324a449ca682c6f3c14