### PR TITLE
Switch URL overlays to Chrome

### DIFF
--- a/vlc_embed.py
+++ b/vlc_embed.py
@@ -27,15 +27,26 @@ CACHE_DIR = RUN_DIR / "cache"
 
 def _find_chrome() -> Optional[str]:
     """Return path to a Chrome/Chromium executable if available."""
-    for name in (
+    candidates = [
         "google-chrome",
         "chrome",
         "chromium-browser",
         "chromium",
-    ):
-        path = shutil.which(name)
-        if path:
-            return path
+    ]
+    if sys.platform.startswith("win"):
+        candidates.extend([
+            os.path.join(os.environ.get("PROGRAMFILES", ""), "Google", "Chrome", "Application", "chrome.exe"),
+            os.path.join(os.environ.get("PROGRAMFILES(X86)", ""), "Google", "Chrome", "Application", "chrome.exe"),
+            os.path.join(os.environ.get("LOCALAPPDATA", ""), "Google", "Chrome", "Application", "chrome.exe"),
+        ])
+    for name in candidates:
+        if os.path.isabs(name):
+            if os.path.exists(name):
+                return name
+        else:
+            path = shutil.which(name)
+            if path:
+                return path
     return None
 
 

--- a/vlc_playlist.py
+++ b/vlc_playlist.py
@@ -36,15 +36,26 @@ CACHE_DIR = RUN_DIR / "cache"
 
 def _find_chrome() -> Optional[str]:
     """Return path to a Chrome/Chromium executable if available."""
-    for name in (
+    candidates = [
         "google-chrome",
         "chrome",
         "chromium-browser",
         "chromium",
-    ):
-        path = shutil.which(name)
-        if path:
-            return path
+    ]
+    if sys.platform.startswith("win"):
+        candidates.extend([
+            os.path.join(os.environ.get("PROGRAMFILES", ""), "Google", "Chrome", "Application", "chrome.exe"),
+            os.path.join(os.environ.get("PROGRAMFILES(X86)", ""), "Google", "Chrome", "Application", "chrome.exe"),
+            os.path.join(os.environ.get("LOCALAPPDATA", ""), "Google", "Chrome", "Application", "chrome.exe"),
+        ])
+    for name in candidates:
+        if os.path.isabs(name):
+            if os.path.exists(name):
+                return name
+        else:
+            path = shutil.which(name)
+            if path:
+                return path
     return None
 
 


### PR DESCRIPTION
## Summary
- add helper to launch Chrome for URL overlays
- open URLs in Chrome instead of tkinterweb
- clean up Chrome processes when overlays close

## Testing
- `python -m py_compile gui_client.py vlc_embed.py vlc_playlist.py display_config.py scheduler.py`

------
https://chatgpt.com/codex/tasks/task_e_68839ec270f88324a36b28c57729bd9f