### PR TITLE
Improve webview speed on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A simple GUI/WebSocket client to fetch broadcast schedules and play TTS audio.
 Install dependencies (requires Python 3.8+):
 
 ```bash
-pip install websockets "httpx[http2]" pillow pystray python-vlc
+pip install websockets "httpx[http2]" pillow pystray python-vlc pywebview
 ```
 
 `httpx` is used with HTTP/2 enabled. If the optional `h2` package is not installed
@@ -58,6 +58,10 @@ the VLC window.  Each entry should contain `ImageUrl`, `X`, `Y`, `Width`,
 web view is shown on the specified monitor.  `GuiOrder` starts at `0` and lower
 numbers are placed above higher values, allowing precise control of the
 stacking order.  GIF images animate and transparency is respected.
+
+On Windows systems, URL overlays launch a separate window using
+`pywebview` with the Edge WebView2 engine for significantly improved
+rendering performance compared to the previous Tkinter-based web view.
 
 The client also handles playlist messages. When a playlist is received it
 is passed to `vlc_playlist.py` for fullscreen playback. A subsequent

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ pystray
 pillow
 python-vlc
 tkinterweb
+pywebview

--- a/vlc_embed.py
+++ b/vlc_embed.py
@@ -6,6 +6,7 @@ import tkinter as tk
 import vlc
 import pathlib
 import hashlib
+import subprocess
 from urllib.parse import urlparse, urlunparse
 import httpx
 import io
@@ -158,6 +159,12 @@ def _clear_gui_elements(monitor: int) -> None:
                 win.destroy()
             except Exception:
                 pass
+        proc = entry.get("proc")
+        if proc is not None:
+            try:
+                proc.terminate()
+            except Exception:
+                pass
     _gui_entries[monitor] = []
 
 
@@ -252,17 +259,46 @@ def _apply_gui_images(monitor: int) -> None:
             player.play()
             entry.update({"player": player})
         elif kind == "url":
-            try:
-                from tkinterweb import HtmlFrame
-                web = HtmlFrame(top)
-                web.load_website(url)
-                web.pack(fill=tk.BOTH, expand=True)
-                entry.update({"web": web})
-            except Exception:
-                import webbrowser
-                webbrowser.open(url)
-                top.destroy()
-                continue
+            if sys.platform.startswith("win"):
+                try:
+                    cmd = [
+                        sys.executable,
+                        str(RUN_DIR / "webview_embed.py"),
+                        url,
+                        str(width or 800),
+                        str(height or 600),
+                        str(base_x + x),
+                        str(base_y + y),
+                    ]
+                    proc = subprocess.Popen(cmd)
+                    entry.update({"proc": proc, "window": None})
+                    top.destroy()
+                    top = None
+                except Exception as e:
+                    print(f"Failed to launch webview: {e}")
+                    try:
+                        from tkinterweb import HtmlFrame
+                        web = HtmlFrame(top)
+                        web.load_website(url)
+                        web.pack(fill=tk.BOTH, expand=True)
+                        entry.update({"web": web})
+                    except Exception:
+                        import webbrowser
+                        webbrowser.open(url)
+                        top.destroy()
+                        continue
+            else:
+                try:
+                    from tkinterweb import HtmlFrame
+                    web = HtmlFrame(top)
+                    web.load_website(url)
+                    web.pack(fill=tk.BOTH, expand=True)
+                    entry.update({"web": web})
+                except Exception:
+                    import webbrowser
+                    webbrowser.open(url)
+                    top.destroy()
+                    continue
         else:
             top.destroy()
             continue

--- a/vlc_playlist.py
+++ b/vlc_playlist.py
@@ -18,6 +18,7 @@ import vlc
 from urllib.parse import urlparse, urlunparse
 import pathlib
 import hashlib
+import subprocess
 import httpx
 import io
 import time
@@ -94,6 +95,12 @@ def _clear_gui_elements(monitor: int) -> None:
         if win is not None:
             try:
                 win.destroy()
+            except Exception:
+                pass
+        proc = entry.get("proc")
+        if proc is not None:
+            try:
+                proc.terminate()
             except Exception:
                 pass
     _gui_entries[monitor] = []
@@ -190,17 +197,46 @@ def _apply_gui_images(monitor: int) -> None:
             player.play()
             entry.update({"player": player})
         elif kind == "url":
-            try:
-                from tkinterweb import HtmlFrame
-                web = HtmlFrame(top)
-                web.load_website(url)
-                web.pack(fill=tk.BOTH, expand=True)
-                entry.update({"web": web})
-            except Exception:
-                import webbrowser
-                webbrowser.open(url)
-                top.destroy()
-                continue
+            if sys.platform.startswith("win"):
+                try:
+                    cmd = [
+                        sys.executable,
+                        str(RUN_DIR / "webview_embed.py"),
+                        url,
+                        str(width or 800),
+                        str(height or 600),
+                        str(base_x + x),
+                        str(base_y + y),
+                    ]
+                    proc = subprocess.Popen(cmd)
+                    entry.update({"proc": proc, "window": None})
+                    top.destroy()
+                    top = None
+                except Exception as e:
+                    print(f"Failed to launch webview: {e}")
+                    try:
+                        from tkinterweb import HtmlFrame
+                        web = HtmlFrame(top)
+                        web.load_website(url)
+                        web.pack(fill=tk.BOTH, expand=True)
+                        entry.update({"web": web})
+                    except Exception:
+                        import webbrowser
+                        webbrowser.open(url)
+                        top.destroy()
+                        continue
+            else:
+                try:
+                    from tkinterweb import HtmlFrame
+                    web = HtmlFrame(top)
+                    web.load_website(url)
+                    web.pack(fill=tk.BOTH, expand=True)
+                    entry.update({"web": web})
+                except Exception:
+                    import webbrowser
+                    webbrowser.open(url)
+                    top.destroy()
+                    continue
         else:
             top.destroy()
             continue

--- a/webview_embed.py
+++ b/webview_embed.py
@@ -1,0 +1,31 @@
+import sys
+import webview
+
+
+def main():
+    if len(sys.argv) < 2:
+        print("Usage: webview_embed.py <url> [width height x y]")
+        return
+    url = sys.argv[1]
+    width = int(sys.argv[2]) if len(sys.argv) > 2 else 800
+    height = int(sys.argv[3]) if len(sys.argv) > 3 else 600
+    x = int(sys.argv[4]) if len(sys.argv) > 4 else None
+    y = int(sys.argv[5]) if len(sys.argv) > 5 else None
+
+    window = webview.create_window(
+        "",
+        url,
+        width=width,
+        height=height,
+        x=x,
+        y=y,
+        resizable=False,
+        frameless=True,
+        on_top=True,
+    )
+    gui = "edgechromium" if sys.platform.startswith("win") else None
+    webview.start(gui=gui)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- use pywebview-based helper for URL overlays on Windows
- kill helper processes when closing overlays
- document new dependency and behavior in README
- add pywebview to requirements

## Testing
- `python -m compileall -q .`

------
https://chatgpt.com/codex/tasks/task_e_6883a338d5948324adc31c938be9daca