### PR TITLE
Position VLC windows on selected monitor

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A simple GUI/WebSocket client to fetch broadcast schedules and play TTS audio.
 Install dependencies (requires Python 3.8+):
 
 ```bash
-pip install websockets "httpx[http2]" pillow pystray python-vlc
+pip install websockets "httpx[http2]" pillow pystray python-vlc screeninfo
 ```
 
 `httpx` is used with HTTP/2 enabled. If the optional `h2` package is not installed

--- a/display_config.py
+++ b/display_config.py
@@ -34,6 +34,22 @@ def get_monitor_count() -> int:
         return max(1, len(outputs))
 
 
+def get_monitor_geometry(monitor: int = 1) -> tuple[int, int, int, int]:
+    """Return ``(x, y, width, height)`` for the given monitor if available."""
+    try:
+        from screeninfo import get_monitors
+        mons = get_monitors()
+    except Exception:
+        mons = []
+    if not mons:
+        return 0, 0, 0, 0
+    if monitor < 1 or monitor > len(mons):
+        mon = mons[0]
+    else:
+        mon = mons[monitor - 1]
+    return int(mon.x), int(mon.y), int(mon.width), int(mon.height)
+
+
 def set_display_config(
     resolution: Optional[str] = None,
     orientation: Optional[Union[int, str]] = None,

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ pystray
 pillow
 python-vlc
 tkinterweb
+screeninfo

--- a/vlc_embed.py
+++ b/vlc_embed.py
@@ -13,6 +13,7 @@ import io
 import time
 from typing import Optional, List, Dict
 from PIL import Image, ImageTk, ImageSequence
+import display_config
 
 
 DEFAULT_URL = "http://nas.3no.kr/test.mp4"
@@ -334,6 +335,12 @@ def run(
     global _roots, _players
     root = tk.Tk()
     _roots[monitor] = root
+    try:
+        sx, sy, sw, sh = display_config.get_monitor_geometry(monitor)
+        if sw and sh:
+            root.geometry(f"{sw}x{sh}+{sx}+{sy}")
+    except Exception:
+        pass
     root.attributes("-fullscreen", True)
     root.configure(background="black")
     frame = tk.Frame(root, background="black")

--- a/vlc_playlist.py
+++ b/vlc_playlist.py
@@ -23,6 +23,7 @@ import io
 import time
 from typing import Optional, List, Dict
 from PIL import Image, ImageTk, ImageSequence
+import display_config
 
 DEFAULT_IMAGE_DURATION = 5
 
@@ -374,6 +375,12 @@ def run(
 
     root = tk.Tk()
     _roots[monitor] = root
+    try:
+        sx, sy, sw, sh = display_config.get_monitor_geometry(monitor)
+        if sw and sh:
+            root.geometry(f"{sw}x{sh}+{sx}+{sy}")
+    except Exception:
+        pass
     root.attributes("-fullscreen", True)
     root.configure(background="black")
     frame = tk.Frame(root, background="black")


### PR DESCRIPTION
## Summary
- add `get_monitor_geometry()` utility using `screeninfo`
- move fullscreen VLC windows to the chosen monitor in `vlc_embed.py` and `vlc_playlist.py`
- mention `screeninfo` in docs and requirements

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6889e0aaecf48324880405d3ca292542