### PR TITLE
Add monitor-aware window positioning

### DIFF
--- a/display_config.py
+++ b/display_config.py
@@ -1,7 +1,7 @@
 import sys
 import subprocess
 import ctypes
-from typing import Optional, Union, List
+from typing import Optional, Union, List, Tuple
 
 
 def _xrandr_outputs() -> List[str]:
@@ -32,6 +32,83 @@ def get_monitor_count() -> int:
     else:
         outputs = _xrandr_outputs()
         return max(1, len(outputs))
+
+
+def get_monitor_geometry(monitor: int = 1) -> Optional[Tuple[int, int, int, int]]:
+    """Return the (x, y, width, height) of ``monitor`` if detectable."""
+    try:
+        from screeninfo import get_monitors
+
+        monitors = get_monitors()
+        if 1 <= monitor <= len(monitors):
+            m = monitors[monitor - 1]
+            return int(m.x), int(m.y), int(m.width), int(m.height)
+    except Exception:
+        pass
+
+    if sys.platform.startswith("win"):
+        try:
+            user32 = ctypes.windll.user32
+            monitors = []
+
+            class RECT(ctypes.Structure):
+                _fields_ = [
+                    ("left", ctypes.c_long),
+                    ("top", ctypes.c_long),
+                    ("right", ctypes.c_long),
+                    ("bottom", ctypes.c_long),
+                ]
+
+            MonitorEnumProc = ctypes.WINFUNCTYPE(
+                ctypes.c_int,
+                ctypes.c_ulong,
+                ctypes.c_ulong,
+                ctypes.POINTER(RECT),
+                ctypes.c_double,
+            )
+
+            def _callback(hMon, hDC, lprc, dwData):
+                r = lprc.contents
+                monitors.append((r.left, r.top, r.right - r.left, r.bottom - r.top))
+                return 1
+
+            user32.EnumDisplayMonitors(0, 0, MonitorEnumProc(_callback), 0)
+            if 1 <= monitor <= len(monitors):
+                return monitors[monitor - 1]
+        except Exception:
+            pass
+    else:
+        try:
+            out = subprocess.run(["xrandr"], capture_output=True, text=True)
+            if out.returncode == 0:
+                idx = 0
+                for line in out.stdout.splitlines():
+                    if " connected" in line:
+                        idx += 1
+                        if idx == monitor:
+                            for part in line.split():
+                                if "x" in part and "+" in part:
+                                    try:
+                                        res, x, y = part.split("+")
+                                        w, h = res.split("x")
+                                        return int(x), int(y), int(w), int(h)
+                                    except Exception:
+                                        pass
+                            break
+        except Exception:
+            pass
+
+    try:
+        import tkinter as tk
+
+        root = tk.Tk()
+        root.withdraw()
+        w = root.winfo_screenwidth()
+        h = root.winfo_screenheight()
+        root.destroy()
+        return 0, 0, int(w), int(h)
+    except Exception:
+        return None
 
 
 def set_display_config(

--- a/vlc_embed.py
+++ b/vlc_embed.py
@@ -4,6 +4,7 @@ import sys
 import ctypes
 import tkinter as tk
 import vlc
+import display_config
 import pathlib
 import hashlib
 import os
@@ -334,6 +335,13 @@ def run(
     global _roots, _players
     root = tk.Tk()
     _roots[monitor] = root
+    geom = display_config.get_monitor_geometry(monitor)
+    if geom:
+        gx, gy, _, _ = geom
+        try:
+            root.geometry(f"+{gx}+{gy}")
+        except Exception:
+            pass
     root.attributes("-fullscreen", True)
     root.configure(background="black")
     frame = tk.Frame(root, background="black")

--- a/vlc_playlist.py
+++ b/vlc_playlist.py
@@ -15,6 +15,7 @@ import os
 import ctypes
 import tkinter as tk
 import vlc
+import display_config
 from urllib.parse import urlparse, urlunparse
 import pathlib
 import hashlib
@@ -374,6 +375,13 @@ def run(
 
     root = tk.Tk()
     _roots[monitor] = root
+    geom = display_config.get_monitor_geometry(monitor)
+    if geom:
+        gx, gy, _, _ = geom
+        try:
+            root.geometry(f"+{gx}+{gy}")
+        except Exception:
+            pass
     root.attributes("-fullscreen", True)
     root.configure(background="black")
     frame = tk.Frame(root, background="black")


### PR DESCRIPTION
## Summary
- implement `get_monitor_geometry` in `display_config` to fetch monitor bounds
- use monitor geometry in `vlc_embed` and `vlc_playlist` so VLC windows open on the right monitor

## Testing
- `python -m py_compile display_config.py vlc_embed.py vlc_playlist.py enterplayer.py`
- `python -m py_compile *.py`


------
https://chatgpt.com/codex/tasks/task_e_6889e27c8a308324934185db9d0e822b