### PR TITLE
Handle monitor geometry for multi-display

### DIFF
--- a/display_config.py
+++ b/display_config.py
@@ -34,6 +34,75 @@ def get_monitor_count() -> int:
         return max(1, len(outputs))
 
 
+def get_monitor_geometry(monitor: int = 1) -> Optional[tuple[int, int, int, int]]:
+    """Return ``(x, y, width, height)`` of the given monitor if available."""
+    if monitor < 1:
+        return None
+    try:
+        from screeninfo import get_monitors
+
+        mons = get_monitors()
+        if 0 < monitor <= len(mons):
+            m = mons[monitor - 1]
+            return int(m.x), int(m.y), int(m.width), int(m.height)
+    except Exception:
+        pass
+
+    if sys.platform.startswith("win"):
+        try:
+            user32 = ctypes.windll.user32
+
+            class RECT(ctypes.Structure):
+                _fields_ = [
+                    ("left", ctypes.c_long),
+                    ("top", ctypes.c_long),
+                    ("right", ctypes.c_long),
+                    ("bottom", ctypes.c_long),
+                ]
+
+            def callback(hmon, hdc, rect, lparam):
+                r = rect.contents
+                monitors.append(
+                    (r.left, r.top, r.right - r.left, r.bottom - r.top)
+                )
+                return 1
+
+            monitors = []
+            MONITORENUMPROC = ctypes.WINFUNCTYPE(
+                ctypes.c_int,
+                ctypes.c_ulong,
+                ctypes.c_ulong,
+                ctypes.POINTER(RECT),
+                ctypes.c_double,
+            )
+            user32.EnumDisplayMonitors(0, 0, MONITORENUMPROC(callback), 0)
+            if 0 < monitor <= len(monitors):
+                return monitors[monitor - 1]
+        except Exception:
+            pass
+    else:
+        try:
+            out = subprocess.run(["xrandr"], capture_output=True, text=True)
+            if out.returncode == 0:
+                geoms = []
+                for line in out.stdout.splitlines():
+                    if " connected" in line:
+                        tokens = line.split()
+                        geom = next(
+                            (t for t in tokens if "+" in t and "x" in t), None
+                        )
+                        if geom:
+                            res, xs, ys = geom.split("+")
+                            w, h = res.split("x")
+                            geoms.append((int(xs), int(ys), int(w), int(h)))
+                if 0 < monitor <= len(geoms):
+                    return geoms[monitor - 1]
+        except Exception:
+            pass
+
+    return None
+
+
 def set_display_config(
     resolution: Optional[str] = None,
     orientation: Optional[Union[int, str]] = None,

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ pystray
 pillow
 python-vlc
 tkinterweb
+screeninfo

--- a/vlc_embed.py
+++ b/vlc_embed.py
@@ -13,6 +13,7 @@ import io
 import time
 from typing import Optional, List, Dict
 from PIL import Image, ImageTk, ImageSequence
+import display_config
 
 
 DEFAULT_URL = "http://nas.3no.kr/test.mp4"
@@ -334,6 +335,10 @@ def run(
     global _roots, _players
     root = tk.Tk()
     _roots[monitor] = root
+    geom = display_config.get_monitor_geometry(monitor)
+    if geom:
+        gx, gy, gw, gh = geom
+        root.geometry(f"{gw}x{gh}+{gx}+{gy}")
     root.attributes("-fullscreen", True)
     root.configure(background="black")
     frame = tk.Frame(root, background="black")

--- a/vlc_playlist.py
+++ b/vlc_playlist.py
@@ -23,6 +23,7 @@ import io
 import time
 from typing import Optional, List, Dict
 from PIL import Image, ImageTk, ImageSequence
+import display_config
 
 DEFAULT_IMAGE_DURATION = 5
 
@@ -374,6 +375,10 @@ def run(
 
     root = tk.Tk()
     _roots[monitor] = root
+    geom = display_config.get_monitor_geometry(monitor)
+    if geom:
+        gx, gy, gw, gh = geom
+        root.geometry(f"{gw}x{gh}+{gx}+{gy}")
     root.attributes("-fullscreen", True)
     root.configure(background="black")
     frame = tk.Frame(root, background="black")


### PR DESCRIPTION
## Summary
- add `get_monitor_geometry` helper
- position Tk windows on the requested monitor in `vlc_embed` and `vlc_playlist`
- require `screeninfo`

## Testing
- `python -m py_compile display_config.py vlc_embed.py vlc_playlist.py enterplayer.py scheduler.py`
- `pip install -r requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_688a07e583e88324a44ca26588ee7b68