### PR TITLE
Fix multi-monitor window placement

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A simple GUI/WebSocket client to fetch broadcast schedules and play TTS audio.
 Install dependencies (requires Python 3.8+):
 
 ```bash
-pip install websockets "httpx[http2]" pillow pystray python-vlc
+pip install websockets "httpx[http2]" pillow pystray python-vlc screeninfo
 ```
 
 `httpx` is used with HTTP/2 enabled. If the optional `h2` package is not installed

--- a/display_config.py
+++ b/display_config.py
@@ -1,7 +1,7 @@
 import sys
 import subprocess
 import ctypes
-from typing import Optional, Union, List
+from typing import Optional, Union, List, Tuple
 
 
 def _xrandr_outputs() -> List[str]:
@@ -32,6 +32,33 @@ def get_monitor_count() -> int:
     else:
         outputs = _xrandr_outputs()
         return max(1, len(outputs))
+
+
+def get_monitor_geometry(monitor: int = 1) -> Tuple[int, int, int, int]:
+    """Return ``(x, y, width, height)`` for the given monitor."""
+    try:
+        from screeninfo import get_monitors
+
+        mons = get_monitors()
+        if not mons:
+            raise RuntimeError("no monitors")
+        if monitor < 1 or monitor > len(mons):
+            m = mons[0]
+        else:
+            m = mons[monitor - 1]
+        return int(m.x), int(m.y), int(m.width), int(m.height)
+    except Exception:
+        try:
+            import tkinter as tk
+
+            root = tk.Tk()
+            root.withdraw()
+            width = root.winfo_screenwidth()
+            height = root.winfo_screenheight()
+            root.destroy()
+        except Exception:
+            width = height = 0
+        return 0, 0, int(width), int(height)
 
 
 def set_display_config(

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ pystray
 pillow
 python-vlc
 tkinterweb
+screeninfo

--- a/vlc_embed.py
+++ b/vlc_embed.py
@@ -13,6 +13,7 @@ import io
 import time
 from typing import Optional, List, Dict
 from PIL import Image, ImageTk, ImageSequence
+import display_config
 
 
 DEFAULT_URL = "http://nas.3no.kr/test.mp4"
@@ -334,6 +335,9 @@ def run(
     global _roots, _players
     root = tk.Tk()
     _roots[monitor] = root
+    x0, y0, mw, mh = display_config.get_monitor_geometry(monitor)
+    root.geometry(f"{mw}x{mh}+{x0}+{y0}")
+    root.update_idletasks()
     root.attributes("-fullscreen", True)
     root.configure(background="black")
     frame = tk.Frame(root, background="black")

--- a/vlc_playlist.py
+++ b/vlc_playlist.py
@@ -23,6 +23,7 @@ import io
 import time
 from typing import Optional, List, Dict
 from PIL import Image, ImageTk, ImageSequence
+import display_config
 
 DEFAULT_IMAGE_DURATION = 5
 
@@ -374,6 +375,9 @@ def run(
 
     root = tk.Tk()
     _roots[monitor] = root
+    x0, y0, mw, mh = display_config.get_monitor_geometry(monitor)
+    root.geometry(f"{mw}x{mh}+{x0}+{y0}")
+    root.update_idletasks()
     root.attributes("-fullscreen", True)
     root.configure(background="black")
     frame = tk.Frame(root, background="black")


### PR DESCRIPTION
## Summary
- add `get_monitor_geometry` helper using `screeninfo`
- position VLC windows on the correct monitor
- document new dependency `screeninfo`

## Testing
- `python -m py_compile display_config.py vlc_embed.py vlc_playlist.py enterplayer.py scheduler.py`

------
https://chatgpt.com/codex/tasks/task_e_688a07e583e88324a44ca26588ee7b68