### PR TITLE
Fix multi-monitor window placement

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A simple GUI/WebSocket client to fetch broadcast schedules and play TTS audio.
 Install dependencies (requires Python 3.8+):
 
 ```bash
-pip install websockets "httpx[http2]" pillow pystray python-vlc
+pip install websockets "httpx[http2]" pillow pystray python-vlc screeninfo
 ```
 
 `httpx` is used with HTTP/2 enabled. If the optional `h2` package is not installed

--- a/README.md
+++ b/README.md
@@ -10,6 +10,10 @@ Install dependencies (requires Python 3.8+):
 pip install websockets "httpx[http2]" pillow pystray python-vlc screeninfo
 ```
 
+`screeninfo` is optional but recommended for detecting monitor geometry. On
+Linux systems without it installed, the helper scripts fall back to parsing the
+output of `xrandr`.
+
 `httpx` is used with HTTP/2 enabled. If the optional `h2` package is not installed
 (i.e. if you only run `pip install httpx`), the program will fail with an error
 similar to:

--- a/display_config.py
+++ b/display_config.py
@@ -92,6 +92,24 @@ def get_monitor_geometry(monitor: int = 1) -> Optional[Tuple[int, int, int, int]
             return None
 
 
+def apply_window_geometry(window, monitor: int = 1) -> None:
+    """Move ``window`` to the specified monitor if geometry is available."""
+    geom = get_monitor_geometry(monitor)
+    if geom is None:
+        return
+    x, y, w, h = geom
+    try:
+        window.geometry(f"{w}x{h}+{x}+{y}")
+    except Exception:
+        pass
+    if sys.platform.startswith("win"):
+        try:
+            hwnd = int(window.winfo_id())
+            ctypes.windll.user32.MoveWindow(hwnd, x, y, w, h, True)
+        except Exception:
+            pass
+
+
 def set_display_config(
     resolution: Optional[str] = None,
     orientation: Optional[Union[int, str]] = None,

--- a/display_config.py
+++ b/display_config.py
@@ -99,6 +99,10 @@ def apply_window_geometry(window, monitor: int = 1) -> None:
         return
     x, y, w, h = geom
     try:
+        window.update_idletasks()
+    except Exception:
+        pass
+    try:
         window.geometry(f"{w}x{h}+{x}+{y}")
     except Exception:
         pass
@@ -222,22 +226,51 @@ if sys.platform.startswith('win'):
     }
 
     def _win_monitor_geometries() -> List[Tuple[int, int, int, int]]:
+        """Return monitor rectangles using EnumDisplayMonitors."""
         geoms: List[Tuple[int, int, int, int]] = []
         try:
             user32 = ctypes.windll.user32
-            count = int(user32.GetSystemMetrics(80))
+
+            class RECT(ctypes.Structure):
+                _fields_ = [
+                    ("left", ctypes.c_long),
+                    ("top", ctypes.c_long),
+                    ("right", ctypes.c_long),
+                    ("bottom", ctypes.c_long),
+                ]
+
+            class MONITORINFO(ctypes.Structure):
+                _fields_ = [
+                    ("cbSize", ctypes.c_ulong),
+                    ("rcMonitor", RECT),
+                    ("rcWork", RECT),
+                    ("dwFlags", ctypes.c_ulong),
+                ]
+
+            MONITORENUMPROC = ctypes.WINFUNCTYPE(
+                ctypes.c_int,
+                ctypes.c_ulong,
+                ctypes.c_ulong,
+                ctypes.POINTER(RECT),
+                ctypes.c_double,
+            )
+
+            def callback(hMonitor, hdcMonitor, lprcMonitor, lParam):
+                info = MONITORINFO()
+                info.cbSize = ctypes.sizeof(MONITORINFO)
+                if user32.GetMonitorInfoW(hMonitor, ctypes.byref(info)):
+                    x = int(info.rcMonitor.left)
+                    y = int(info.rcMonitor.top)
+                    w = int(info.rcMonitor.right - info.rcMonitor.left)
+                    h = int(info.rcMonitor.bottom - info.rcMonitor.top)
+                    geoms.append((x, y, w, h))
+                return 1
+
+            user32.EnumDisplayMonitors(
+                0, 0, MONITORENUMPROC(callback), 0
+            )
         except Exception:
             return geoms
-        for i in range(1, count + 1):
-            try:
-                dev_name = f"\\\\.\\DISPLAY{i}"
-                dm = DEVMODE()
-                dm.dmSize = ctypes.sizeof(DEVMODE)
-                if user32.EnumDisplaySettingsW(dev_name, ENUM_CURRENT_SETTINGS, ctypes.byref(dm)) == 0:
-                    continue
-                geoms.append((int(dm.dmPositionX), int(dm.dmPositionY), int(dm.dmPelsWidth), int(dm.dmPelsHeight)))
-            except Exception:
-                continue
         return geoms
 
     def _set_windows_display(

--- a/display_config.py
+++ b/display_config.py
@@ -1,7 +1,12 @@
 import sys
 import subprocess
 import ctypes
-from typing import Optional, Union, List
+from typing import Optional, Union, List, Tuple
+
+try:
+    from screeninfo import get_monitors
+except Exception:  # pragma: no cover - optional dependency may not be installed
+    get_monitors = None
 
 
 def _xrandr_outputs() -> List[str]:
@@ -32,6 +37,23 @@ def get_monitor_count() -> int:
     else:
         outputs = _xrandr_outputs()
         return max(1, len(outputs))
+
+
+def get_monitor_geometry(monitor: int = 1) -> Optional[Tuple[int, int, int, int]]:
+    """Return ``(x, y, width, height)`` for ``monitor`` if available."""
+    if get_monitors is None:
+        return None
+    try:
+        mons = get_monitors()
+    except Exception:
+        return None
+    if not mons or monitor < 1 or monitor > len(mons):
+        return None
+    m = mons[monitor - 1]
+    try:
+        return int(m.x), int(m.y), int(m.width), int(m.height)
+    except Exception:
+        return None
 
 
 def set_display_config(

--- a/display_config.py
+++ b/display_config.py
@@ -1,7 +1,7 @@
 import sys
 import subprocess
 import ctypes
-from typing import Optional, Union, List, Tuple
+from typing import Optional, Union, List, Tuple, Dict
 
 try:
     from screeninfo import get_monitors
@@ -26,6 +26,34 @@ def _xrandr_outputs() -> List[str]:
     return primary + others
 
 
+def _xrandr_monitor_geometries() -> List[Tuple[int, int, int, int]]:
+    """Return monitor geometries via xrandr if available."""
+    out = subprocess.run(["xrandr"], capture_output=True, text=True)
+    if out.returncode != 0:
+        return []
+    geoms: Dict[str, Tuple[int, int, int, int]] = {}
+    for line in out.stdout.splitlines():
+        if " connected" not in line:
+            continue
+        parts = line.split()
+        name = parts[0]
+        geom = None
+        for p in parts:
+            if "x" in p and "+" in p and not p.startswith("("):
+                geom = p
+                break
+        if geom is None:
+            continue
+        try:
+            res, x, y = geom.split("+")[:3]
+            w, h = res.split("x")
+            geoms[name] = (int(x), int(y), int(w), int(h))
+        except Exception:
+            continue
+    outputs = _xrandr_outputs()
+    return [geoms.get(o, (0, 0, 0, 0)) for o in outputs if o in geoms]
+
+
 def get_monitor_count() -> int:
     """Return the number of connected displays."""
     if sys.platform.startswith("win"):
@@ -41,19 +69,27 @@ def get_monitor_count() -> int:
 
 def get_monitor_geometry(monitor: int = 1) -> Optional[Tuple[int, int, int, int]]:
     """Return ``(x, y, width, height)`` for ``monitor`` if available."""
-    if get_monitors is None:
-        return None
-    try:
-        mons = get_monitors()
-    except Exception:
-        return None
+    mons = []
+    if get_monitors is not None:
+        try:
+            mons = get_monitors()
+        except Exception:
+            mons = []
+    if not mons:
+        if sys.platform.startswith("win"):
+            mons = _win_monitor_geometries()
+        else:
+            mons = _xrandr_monitor_geometries()
     if not mons or monitor < 1 or monitor > len(mons):
         return None
     m = mons[monitor - 1]
     try:
-        return int(m.x), int(m.y), int(m.width), int(m.height)
+        return int(m[0]), int(m[1]), int(m[2]), int(m[3])
     except Exception:
-        return None
+        try:
+            return int(m.x), int(m.y), int(m.width), int(m.height)  # type: ignore[attr-defined]
+        except Exception:
+            return None
 
 
 def set_display_config(
@@ -166,6 +202,25 @@ if sys.platform.startswith('win'):
         180: 2,
         270: 3,
     }
+
+    def _win_monitor_geometries() -> List[Tuple[int, int, int, int]]:
+        geoms: List[Tuple[int, int, int, int]] = []
+        try:
+            user32 = ctypes.windll.user32
+            count = int(user32.GetSystemMetrics(80))
+        except Exception:
+            return geoms
+        for i in range(1, count + 1):
+            try:
+                dev_name = f"\\\\.\\DISPLAY{i}"
+                dm = DEVMODE()
+                dm.dmSize = ctypes.sizeof(DEVMODE)
+                if user32.EnumDisplaySettingsW(dev_name, ENUM_CURRENT_SETTINGS, ctypes.byref(dm)) == 0:
+                    continue
+                geoms.append((int(dm.dmPositionX), int(dm.dmPositionY), int(dm.dmPelsWidth), int(dm.dmPelsHeight)))
+            except Exception:
+                continue
+        return geoms
 
     def _set_windows_display(
         width: Optional[int],

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ pystray
 pillow
 python-vlc
 tkinterweb
+screeninfo

--- a/vlc_embed.py
+++ b/vlc_embed.py
@@ -335,6 +335,7 @@ def run(
     global _roots, _players
     root = tk.Tk()
     _roots[monitor] = root
+    root.attributes("-fullscreen", True)
     geom = display_config.get_monitor_geometry(monitor)
     if geom is not None:
         gx, gy, gw, gh = geom
@@ -342,7 +343,6 @@ def run(
             root.geometry(f"{gw}x{gh}+{gx}+{gy}")
         except Exception:
             pass
-    root.attributes("-fullscreen", True)
     root.configure(background="black")
     frame = tk.Frame(root, background="black")
     if width and height:

--- a/vlc_embed.py
+++ b/vlc_embed.py
@@ -13,6 +13,7 @@ import io
 import time
 from typing import Optional, List, Dict
 from PIL import Image, ImageTk, ImageSequence
+import display_config
 
 
 DEFAULT_URL = "http://nas.3no.kr/test.mp4"
@@ -334,6 +335,13 @@ def run(
     global _roots, _players
     root = tk.Tk()
     _roots[monitor] = root
+    geom = display_config.get_monitor_geometry(monitor)
+    if geom is not None:
+        gx, gy, gw, gh = geom
+        try:
+            root.geometry(f"{gw}x{gh}+{gx}+{gy}")
+        except Exception:
+            pass
     root.attributes("-fullscreen", True)
     root.configure(background="black")
     frame = tk.Frame(root, background="black")

--- a/vlc_embed.py
+++ b/vlc_embed.py
@@ -336,13 +336,7 @@ def run(
     root = tk.Tk()
     _roots[monitor] = root
     root.attributes("-fullscreen", True)
-    geom = display_config.get_monitor_geometry(monitor)
-    if geom is not None:
-        gx, gy, gw, gh = geom
-        try:
-            root.geometry(f"{gw}x{gh}+{gx}+{gy}")
-        except Exception:
-            pass
+    display_config.apply_window_geometry(root, monitor)
     root.configure(background="black")
     frame = tk.Frame(root, background="black")
     if width and height:

--- a/vlc_playlist.py
+++ b/vlc_playlist.py
@@ -375,6 +375,7 @@ def run(
 
     root = tk.Tk()
     _roots[monitor] = root
+    root.attributes("-fullscreen", True)
     geom = display_config.get_monitor_geometry(monitor)
     if geom is not None:
         gx, gy, gw, gh = geom
@@ -382,7 +383,6 @@ def run(
             root.geometry(f"{gw}x{gh}+{gx}+{gy}")
         except Exception:
             pass
-    root.attributes("-fullscreen", True)
     root.configure(background="black")
     frame = tk.Frame(root, background="black")
     if width and height:

--- a/vlc_playlist.py
+++ b/vlc_playlist.py
@@ -376,13 +376,7 @@ def run(
     root = tk.Tk()
     _roots[monitor] = root
     root.attributes("-fullscreen", True)
-    geom = display_config.get_monitor_geometry(monitor)
-    if geom is not None:
-        gx, gy, gw, gh = geom
-        try:
-            root.geometry(f"{gw}x{gh}+{gx}+{gy}")
-        except Exception:
-            pass
+    display_config.apply_window_geometry(root, monitor)
     root.configure(background="black")
     frame = tk.Frame(root, background="black")
     if width and height:

--- a/vlc_playlist.py
+++ b/vlc_playlist.py
@@ -22,6 +22,7 @@ import httpx
 import io
 import time
 from typing import Optional, List, Dict
+import display_config
 from PIL import Image, ImageTk, ImageSequence
 
 DEFAULT_IMAGE_DURATION = 5
@@ -374,6 +375,13 @@ def run(
 
     root = tk.Tk()
     _roots[monitor] = root
+    geom = display_config.get_monitor_geometry(monitor)
+    if geom is not None:
+        gx, gy, gw, gh = geom
+        try:
+            root.geometry(f"{gw}x{gh}+{gx}+{gy}")
+        except Exception:
+            pass
     root.attributes("-fullscreen", True)
     root.configure(background="black")
     frame = tk.Frame(root, background="black")


### PR DESCRIPTION
## Summary
- add screeninfo to detect monitor geometry
- place VLC windows on the correct monitor
- update dependencies and docs

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pip install -r requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_688a07e583e88324a44ca26588ee7b68