### PR TITLE
Add monitor-specific VLC window placement

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,9 @@ Config messages may also include `Resolution` (e.g. `"1920x1080"`) and
 `Orientation` (0-4) fields.  When present, the client attempts to update the
 system's display settings accordingly on Windows and Linux (including
 Raspberry Pi and Orange Pi) using platform specific commands.
+`Monitor1` and `Monitor2` sections may define `VlcX`, `VlcY`, `VlcWidth`
+and `VlcHeight` values which position the VLC window on each monitor.
+If these are omitted the window fills the monitor.
 Additionally a `GuiImages` array may be provided to overlay elements on top of
 the VLC window.  Each entry should contain `ImageUrl`, `X`, `Y`, `Width`,
 `Height`, `GuiKind`, `GuiOrder` and `Monitor` values.  `GuiKind` can be

--- a/vlc_embed.py
+++ b/vlc_embed.py
@@ -1,4 +1,4 @@
-"""Launch a fullscreen VLC window embedded in Tkinter."""
+"""Launch a VLC window attached to a specific monitor."""
 
 import sys
 import ctypes
@@ -326,25 +326,33 @@ def run(
     height: Optional[int] = None,
     monitor: int = 1,
 ) -> None:
-    """Play ``url`` in a fullscreen window with an embedded player.
+    """Play ``url`` on ``monitor`` in a Tk window.
 
-    ``x``/``y`` specify the top left corner of the embedded player within the
-    fullscreen window and ``width``/``height`` control its size.  When no
-    geometry is provided the player fills the entire screen.
+    When ``width`` and ``height`` are provided the window is positioned at
+    ``x``/``y`` relative to the top left corner of the target monitor.  If no
+    geometry is supplied the window fills the entire monitor.
     """
     global _roots, _players
     root = tk.Tk()
     _roots[monitor] = root
-    root.attributes("-fullscreen", True)
-    display_config.apply_window_geometry(root, monitor)
+
+    geom = display_config.get_monitor_geometry(monitor)
+
+    if width is None or height is None:
+        root.attributes("-fullscreen", True)
+        display_config.apply_window_geometry(root, monitor)
+    else:
+        root.overrideredirect(True)
+        gx = gy = 0
+        if geom is not None:
+            gx, gy, _, _ = geom
+        sx = gx + (int(x) if x is not None else 0)
+        sy = gy + (int(y) if y is not None else 0)
+        root.geometry(f"{int(width)}x{int(height)}+{sx}+{sy}")
+
     root.configure(background="black")
     frame = tk.Frame(root, background="black")
-    if width and height:
-        fx = int(x) if x is not None else 0
-        fy = int(y) if y is not None else 0
-        frame.place(x=fx, y=fy, width=int(width), height=int(height))
-    else:
-        frame.pack(fill=tk.BOTH, expand=True)
+    frame.pack(fill=tk.BOTH, expand=True)
     progress_var = tk.StringVar()
     progress_label = tk.Label(root, textvariable=progress_var, fg="white", bg="black")
     progress_label.place(relx=0.5, rely=0.5, anchor="center")

--- a/vlc_playlist.py
+++ b/vlc_playlist.py
@@ -1,4 +1,4 @@
-"""Play a playlist of media items in fullscreen using VLC.
+"""Play a playlist of media items using VLC.
 
 The functions here mirror the previous standalone script behaviour but allow
 embedding the player in the current process.  ``run()`` starts playback of a
@@ -345,11 +345,11 @@ def run(
     height: Optional[int] = None,
     monitor: int = 1,
 ) -> None:
-    """Play playlist defined in ``path`` and reload when it changes.
+    """Play playlist defined in ``path`` on ``monitor``.
 
-    The player always opens a fullscreen window.  When ``width`` and ``height``
-    are supplied the VLC player is embedded at ``x``, ``y`` with the given size.
-    Otherwise the player fills the entire window.
+    When ``width`` and ``height`` are provided the window is positioned at
+    ``x``/``y`` relative to the monitor. If no geometry is supplied the
+    window fills the monitor.
     """
 
     def load() -> tuple[List, int]:
@@ -375,16 +375,24 @@ def run(
 
     root = tk.Tk()
     _roots[monitor] = root
-    root.attributes("-fullscreen", True)
-    display_config.apply_window_geometry(root, monitor)
+
+    geom = display_config.get_monitor_geometry(monitor)
+
+    if width is None or height is None:
+        root.attributes("-fullscreen", True)
+        display_config.apply_window_geometry(root, monitor)
+    else:
+        root.overrideredirect(True)
+        gx = gy = 0
+        if geom is not None:
+            gx, gy, _, _ = geom
+        sx = gx + (int(x) if x is not None else 0)
+        sy = gy + (int(y) if y is not None else 0)
+        root.geometry(f"{int(width)}x{int(height)}+{sx}+{sy}")
+
     root.configure(background="black")
     frame = tk.Frame(root, background="black")
-    if width and height:
-        fx = int(x) if x is not None else 0
-        fy = int(y) if y is not None else 0
-        frame.place(x=fx, y=fy, width=int(width), height=int(height))
-    else:
-        frame.pack(fill=tk.BOTH, expand=True)
+    frame.pack(fill=tk.BOTH, expand=True)
     progress_var = tk.StringVar()
     progress_label = tk.Label(root, textvariable=progress_var, fg="white", bg="black")
     progress_label.place(relx=0.5, rely=0.5, anchor="center")


### PR DESCRIPTION
## Summary
- allow `vlc_embed.run` and `vlc_playlist.run` to position their windows instead of always fullscreen
- document `VlcX`, `VlcY`, `VlcWidth` and `VlcHeight` usage in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_688a187f16408324ac89bbd77f5a060e