### PR TITLE
Add per-monitor window geometry support

### DIFF
--- a/vlc_embed.py
+++ b/vlc_embed.py
@@ -326,25 +326,29 @@ def run(
     height: Optional[int] = None,
     monitor: int = 1,
 ) -> None:
-    """Play ``url`` in a fullscreen window with an embedded player.
+    """Play ``url`` in a window on ``monitor``.
 
-    ``x``/``y`` specify the top left corner of the embedded player within the
-    fullscreen window and ``width``/``height`` control its size.  When no
-    geometry is provided the player fills the entire screen.
+    When ``width`` and ``height`` are supplied the window is positioned at
+    ``x``/``y`` relative to the top left of the chosen monitor.  Otherwise a
+    fullscreen window is created on that monitor.
     """
     global _roots, _players
     root = tk.Tk()
     _roots[monitor] = root
-    root.attributes("-fullscreen", True)
-    display_config.apply_window_geometry(root, monitor)
-    root.configure(background="black")
-    frame = tk.Frame(root, background="black")
+
     if width and height:
+        geom = display_config.get_monitor_geometry(monitor) or (0, 0, 0, 0)
+        base_x, base_y, _, _ = geom
         fx = int(x) if x is not None else 0
         fy = int(y) if y is not None else 0
-        frame.place(x=fx, y=fy, width=int(width), height=int(height))
+        root.geometry(f"{int(width)}x{int(height)}+{base_x + fx}+{base_y + fy}")
     else:
-        frame.pack(fill=tk.BOTH, expand=True)
+        root.attributes("-fullscreen", True)
+        display_config.apply_window_geometry(root, monitor)
+
+    root.configure(background="black")
+    frame = tk.Frame(root, background="black")
+    frame.pack(fill=tk.BOTH, expand=True)
     progress_var = tk.StringVar()
     progress_label = tk.Label(root, textvariable=progress_var, fg="white", bg="black")
     progress_label.place(relx=0.5, rely=0.5, anchor="center")

--- a/vlc_playlist.py
+++ b/vlc_playlist.py
@@ -345,11 +345,10 @@ def run(
     height: Optional[int] = None,
     monitor: int = 1,
 ) -> None:
-    """Play playlist defined in ``path`` and reload when it changes.
+    """Play playlist defined in ``path`` on ``monitor``.
 
-    The player always opens a fullscreen window.  When ``width`` and ``height``
-    are supplied the VLC player is embedded at ``x``, ``y`` with the given size.
-    Otherwise the player fills the entire window.
+    If ``width`` and ``height`` are provided the window is created at ``x``/``y``
+    relative to the selected monitor.  Otherwise a fullscreen window is used.
     """
 
     def load() -> tuple[List, int]:
@@ -375,16 +374,20 @@ def run(
 
     root = tk.Tk()
     _roots[monitor] = root
-    root.attributes("-fullscreen", True)
-    display_config.apply_window_geometry(root, monitor)
-    root.configure(background="black")
-    frame = tk.Frame(root, background="black")
+
     if width and height:
+        geom = display_config.get_monitor_geometry(monitor) or (0, 0, 0, 0)
+        base_x, base_y, _, _ = geom
         fx = int(x) if x is not None else 0
         fy = int(y) if y is not None else 0
-        frame.place(x=fx, y=fy, width=int(width), height=int(height))
+        root.geometry(f"{int(width)}x{int(height)}+{base_x + fx}+{base_y + fy}")
     else:
-        frame.pack(fill=tk.BOTH, expand=True)
+        root.attributes("-fullscreen", True)
+        display_config.apply_window_geometry(root, monitor)
+
+    root.configure(background="black")
+    frame = tk.Frame(root, background="black")
+    frame.pack(fill=tk.BOTH, expand=True)
     progress_var = tk.StringVar()
     progress_label = tk.Label(root, textvariable=progress_var, fg="white", bg="black")
     progress_label.place(relx=0.5, rely=0.5, anchor="center")


### PR DESCRIPTION
## Summary
- allow specifying custom position and size when opening VLC windows
- adjust playlist handling to use the monitor offsets

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_688a187f16408324ac89bbd77f5a060e