### PR TITLE
Fix multi-monitor VLC window placement

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,9 @@ When the server sends a config message with `Playmode` set to `1`,
 `gui_client.py` will launch `vlc_embed.py` to play a provided `StreamURL`
 in a fullscreen embedded VLC window. The helper script attaches VLC to a
 Tkinter window using the correct API for Windows, macOS, or X11-based
-Linux/Raspbian environments.
+Linux/Raspbian environments.  On multi-monitor systems the window is
+positioned on the target display before switching to fullscreen so it
+stays anchored to the chosen monitor just like the GUI overlays.
 If no stream URL is supplied, it defaults to `http://nas.3no.kr/test.mp4`.
 
 Config messages may also include `Resolution` (e.g. `"1920x1080"`) and

--- a/vlc_embed.py
+++ b/vlc_embed.py
@@ -335,8 +335,9 @@ def run(
     global _roots, _players
     root = tk.Tk()
     _roots[monitor] = root
-    root.attributes("-fullscreen", True)
     display_config.apply_window_geometry(root, monitor)
+    root.update_idletasks()
+    root.attributes("-fullscreen", True)
     root.configure(background="black")
     frame = tk.Frame(root, background="black")
     if width and height:

--- a/vlc_playlist.py
+++ b/vlc_playlist.py
@@ -375,8 +375,9 @@ def run(
 
     root = tk.Tk()
     _roots[monitor] = root
-    root.attributes("-fullscreen", True)
     display_config.apply_window_geometry(root, monitor)
+    root.update_idletasks()
+    root.attributes("-fullscreen", True)
     root.configure(background="black")
     frame = tk.Frame(root, background="black")
     if width and height:


### PR DESCRIPTION
## Summary
- place VLC window on the target display before entering fullscreen
- mention multi-monitor placement in README

## Testing
- `python -m py_compile vlc_embed.py vlc_playlist.py display_config.py scheduler.py enterplayer.py`

------
https://chatgpt.com/codex/tasks/task_e_688a249c0e508324b35665eeee943dd0