### PR TITLE
Handle warning broadcast messages

### DIFF
--- a/enterplayer.py
+++ b/enterplayer.py
@@ -15,6 +15,7 @@ DEFAULT_URL = "http://nas.3no.kr/test.mp4"
 import scheduler
 import tempfile
 from typing import Optional
+from urllib.parse import urlparse
 import vlc_embed
 import vlc_playlist
 import display_config
@@ -259,13 +260,18 @@ class WSClient:
         scheduler.play_mp3(audio)
 
     async def play_audio_url(self, url: str, volume: Optional[int] = None) -> None:
-        """Download an MP3 from ``url`` and play it."""
+        """Download an audio file from ``url`` and play it."""
         try:
             async with httpx.AsyncClient(timeout=120) as cli:
                 r = await cli.get(url)
                 r.raise_for_status()
 
-            tmp = tempfile.NamedTemporaryFile(delete=False, suffix=".mp3", dir=RUN_DIR)
+            parsed = urlparse(url)
+            ext = os.path.splitext(parsed.path)[1].lower() or ".mp3"
+            if ext not in {".mp3", ".wav"}:
+                ext = ".mp3"
+
+            tmp = tempfile.NamedTemporaryFile(delete=False, suffix=ext, dir=RUN_DIR)
             tmp.write(r.content)
             tmp.flush()
             tmp.close()
@@ -273,7 +279,7 @@ class WSClient:
             if volume is not None:
                 scheduler.set_volume(volume)
 
-            scheduler.play_mp3_file(tmp.name)
+            scheduler.play_audio_file(tmp.name)
         except Exception as e:  # noqa: BLE001
             print(f"Failed to play audio from {url}: {e}")
 
@@ -439,6 +445,13 @@ class WSClient:
                     volume = data.get("volume")
                     if url:
                         asyncio.create_task(self.play_audio_url(url, volume))
+                elif isinstance(data, dict) and data.get("type") == "warning-broadcast":
+                    wtype = int(data.get("warning_type", 0))
+                    text = data.get("text", "")
+                    if wtype == 1:
+                        asyncio.create_task(self.play_tts_text(text))
+                    elif wtype == 2 and text:
+                        asyncio.create_task(self.play_audio_url(text))
                 elif isinstance(data, dict) and data.get("type") == "play-tts":
                     text = data.get("text", "")
                     speed = data.get("speed", 1.0)

--- a/scheduler.py
+++ b/scheduler.py
@@ -46,15 +46,19 @@ def _cleanup_process(proc: subprocess.Popen, path: str) -> None:
         pass
 
 
-def _play_mp3_path(path: str) -> None:
-    """Play an MP3 file located at ``path`` and remove it afterwards."""
+def _play_audio_path(path: str) -> None:
+    """Play an audio file located at ``path`` and remove it afterwards."""
     if sys.platform.startswith("win"):
         def play_and_cleanup(p: str) -> None:
             try:
                 import ctypes
-                alias = f"mp3_{os.getpid()}_{threading.get_ident()}"
+                alias = f"audio_{os.getpid()}_{threading.get_ident()}"
                 mci = ctypes.windll.winmm.mciSendStringW
-                mci(f'open "{p}" type mpegvideo alias {alias}', None, 0, None)
+                if p.lower().endswith(".wav"):
+                    ftype = "waveaudio"
+                else:
+                    ftype = "mpegvideo"
+                mci(f'open "{p}" type {ftype} alias {alias}', None, 0, None)
                 mci(f'play {alias} wait', None, 0, None)
                 mci(f'close {alias}', None, 0, None)
             finally:
@@ -65,14 +69,21 @@ def _play_mp3_path(path: str) -> None:
 
         threading.Thread(target=play_and_cleanup, args=(path,), daemon=True).start()
     else:
-        command = ["mpg123", "-q", path]
+        if path.lower().endswith(".wav"):
+            command = ["aplay", "-q", path]
+        else:
+            command = ["mpg123", "-q", path]
         proc = subprocess.Popen(command, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
         threading.Thread(target=_cleanup_process, args=(proc, path), daemon=True).start()
 
 
-def play_mp3_file(path: str) -> None:
-    """Play an MP3 file and delete it after playback completes."""
-    _play_mp3_path(path)
+def play_audio_file(path: str) -> None:
+    """Play an audio file and delete it after playback completes."""
+    _play_audio_path(path)
+
+
+# Backwards compatibility
+play_mp3_file = play_audio_file
 
 
 def set_volume(level: int) -> None:
@@ -99,7 +110,7 @@ def play_mp3(data: bytes) -> None:
     tmp.flush()
     tmp.close()
 
-    _play_mp3_path(tmp.name)
+    _play_audio_path(tmp.name)
 
 
 async def tts_request(text: str, *, speed: float = 1.0, pitch: float = 0.2) -> bytes:


### PR DESCRIPTION
## Summary
- support warning-broadcast messages for TTS or prerecorded audio
- allow playing WAV files in addition to MP3

## Testing
- `python -m py_compile scheduler.py enterplayer.py`


------
https://chatgpt.com/codex/tasks/task_e_689a156d185c8324acb646b5412b448e