### PR TITLE
Ensure Raspbian compatibility by using typing Tuple/Any

### DIFF
--- a/vlc_embed.py
+++ b/vlc_embed.py
@@ -11,7 +11,7 @@ from urllib.parse import urlparse, urlunparse
 import httpx
 import io
 import time
-from typing import Optional, List, Dict
+from typing import Optional, List, Dict, Tuple, Any
 from PIL import Image, ImageTk, ImageSequence
 import display_config
 
@@ -92,8 +92,8 @@ def _attach_handle(player: vlc.MediaPlayer, handle: int) -> None:
 
 _roots: Dict[int, tk.Tk] = {}
 _players: Dict[int, vlc.MediaPlayer] = {}
-_gui_images: Dict[int, List[Dict[str, any]]] = {}
-_gui_entries: Dict[int, List[Dict[str, any]]] = {}
+_gui_images: Dict[int, List[Dict[str, Any]]] = {}
+_gui_entries: Dict[int, List[Dict[str, Any]]] = {}
 
 
 def fix_media_url(url: str) -> str:
@@ -111,7 +111,7 @@ def _load_image_frames(
     width: Optional[int],
     height: Optional[int],
     root: tk.Tk,
-) -> tuple[List, List]:
+) -> Tuple[List, List]:
     """Return a list of PhotoImage frames and their durations."""
     try:
         if urlparse(url).scheme in {"http", "https"}:
@@ -309,7 +309,7 @@ def _apply_gui_images(monitor: int) -> None:
         _gui_entries.setdefault(monitor, []).append(entry)
 
 
-def set_gui_images(images: List[Dict[str, any]], monitor: int = 1) -> None:
+def set_gui_images(images: List[Dict[str, Any]], monitor: int = 1) -> None:
     """Update overlay elements (images, videos, web views) for ``monitor``."""
     _gui_images[monitor] = list(images) if images else []
     root = _roots.get(monitor)

--- a/vlc_playlist.py
+++ b/vlc_playlist.py
@@ -21,7 +21,7 @@ import hashlib
 import httpx
 import io
 import time
-from typing import Optional, List, Dict
+from typing import Optional, List, Dict, Tuple, Any
 import display_config
 from PIL import Image, ImageTk, ImageSequence
 
@@ -40,8 +40,8 @@ _playlist_paths: Dict[int, str] = {}
 _items_map: Dict[int, list] = {}
 _idx_map: Dict[int, int] = {}
 _last_mtimes: Dict[int, float] = {}
-_gui_images: Dict[int, List[Dict[str, any]]] = {}
-_gui_entries: Dict[int, List[Dict[str, any]]] = {}
+_gui_images: Dict[int, List[Dict[str, Any]]] = {}
+_gui_entries: Dict[int, List[Dict[str, Any]]] = {}
 
 
 def _load_image_frames(
@@ -49,7 +49,7 @@ def _load_image_frames(
     width: Optional[int],
     height: Optional[int],
     root: tk.Tk,
-) -> tuple[List, List]:
+) -> Tuple[List, List]:
     try:
         if urlparse(url).scheme in {"http", "https"}:
             r = httpx.get(url, timeout=30)
@@ -246,7 +246,7 @@ def _apply_gui_images(monitor: int) -> None:
         _gui_entries.setdefault(monitor, []).append(entry)
 
 
-def set_gui_images(images: List[Dict[str, any]], monitor: int = 1) -> None:
+def set_gui_images(images: List[Dict[str, Any]], monitor: int = 1) -> None:
     """Update overlay elements (images, videos, web views) for ``monitor``."""
     _gui_images[monitor] = list(images) if images else []
     root = _roots.get(monitor)
@@ -352,7 +352,7 @@ def run(
     Otherwise the player fills the entire window.
     """
 
-    def load() -> tuple[List, int]:
+    def load() -> Tuple[List, int]:
         try:
             with open(path, "r", encoding="utf-8") as f:
                 data = json.load(f)


### PR DESCRIPTION
## Summary
- replace PEP 585 built-in generics with typing Tuple and Any
- update type hints for GUI image helpers to avoid runtime errors on Python < 3.9

## Testing
- `python -m py_compile vlc_embed.py vlc_playlist.py enterplayer.py`
- `python3 enterplayer.py`

------
https://chatgpt.com/codex/tasks/task_e_689bef623b7c8324bc73d0c95f0525b7