### PR TITLE
Enable websocket ping to recover from network loss

### DIFF
--- a/enterplayer.py
+++ b/enterplayer.py
@@ -305,7 +305,13 @@ class WSClient:
             )
             try:
                 self.update_status("Connecting…")
-                async with websockets.connect(ws_url, ping_interval=None, max_size=1 << 20) as ws:
+                async with websockets.connect(
+                    ws_url,
+                    ping_interval=20,
+                    ping_timeout=20,
+                    close_timeout=5,
+                    max_size=1 << 20,
+                ) as ws:
                     self.update_status("Connected")
                     backoff = 1
                     await self.handle_ws(ws)


### PR DESCRIPTION
## Summary
- enable periodic websocket pings to detect dropped connections

## Testing
- `python -m py_compile enterplayer.py`


------
https://chatgpt.com/codex/tasks/task_e_68a12de29e8083248a9e0db62ea406ba