### PR TITLE
Fix weekday mask mapping for schedules

### DIFF
--- a/scheduler.py
+++ b/scheduler.py
@@ -130,11 +130,23 @@ async def tts_request(text: str, *, speed: float = 1.0, pitch: float = 0.2) -> b
 
 
 def parse_days(mask: int) -> List[int]:
-    """Return a list of weekday numbers from mask. Monday=0"""
-    days = []
+    """Return a list of weekday numbers from ``mask``.
+
+    The server represents days using a bit mask with Sunday as the least
+    significant bit (value ``1``). ``datetime.weekday()`` uses ``0`` for
+    Monday, so adjust the mapping accordingly and gracefully handle non-int
+    masks.
+    """
+
+    days: List[int] = []
+    try:
+        mask_int = int(mask)
+    except Exception:
+        return days
+
     for i in range(7):
-        if mask & (1 << i):
-            days.append(i)
+        if mask_int & (1 << i):
+            days.append((i + 6) % 7)
     return days
 
 


### PR DESCRIPTION
## Summary
- Correct day-of-week bitmask interpretation so schedules trigger on the proper weekdays

## Testing
- `python -m py_compile scheduler.py`
- `python - <<'PY'
import scheduler
print('mask1', scheduler.parse_days(1))
print('mask2', scheduler.parse_days(2))
print('mask4', scheduler.parse_days(4))
PY`

------
https://chatgpt.com/codex/tasks/task_e_68a48e4b743083248951f12f0e5bdcc8