### PR TITLE
Handle scheduled broadcasts concurrently

### DIFF
--- a/scheduler.py
+++ b/scheduler.py
@@ -171,9 +171,33 @@ async def scheduler_loop(
     schedules: List[Dict[str, Any]], stop_event: Optional[threading.Event] = None
 ) -> None:
     """Run scheduled playback based on a list of schedule dictionaries."""
+    async def _run_schedule(sch: Dict[str, Any]) -> None:
+        """Execute a single schedule without blocking the main loop."""
+        now = dt.datetime.now()
+        try:
+            print(
+                f"Playing schedule {sch.get('ScheduleID')}: {sch.get('Title')}"
+            )
+            audio = await tts_request(
+                sch.get("TTSContent", ""),
+                speed=sch.get("Speed", 1.0),
+                pitch=sch.get("Pitch", 1.0),
+            )
+            play_mp3(audio)
+            sch["last_run"] = now
+        except Exception as e:  # noqa: BLE001
+            print(f"Failed to play schedule {sch.get('ScheduleID')}: {e}")
+        finally:
+            sch["next_run"] = compute_next_run(
+                sch, now + dt.timedelta(seconds=1)
+            )
+
     for sch in schedules:
         sch["next_run"] = compute_next_run(sch)
         sch["last_run"] = None
+
+    pending_tasks: set[asyncio.Task] = set()
+
     while True:
         if stop_event and stop_event.is_set():
             break
@@ -183,25 +207,14 @@ async def scheduler_loop(
             if nr and nr <= now:
                 last = sch.get("last_run")
                 if last and last.date() == now.date():
-                    sch["next_run"] = compute_next_run(sch, now + dt.timedelta(seconds=1))
-                    continue
-                try:
-                    print(
-                        f"Playing schedule {sch.get('ScheduleID')}: {sch.get('Title')}"
-                    )
-                    audio = await tts_request(
-                        sch.get("TTSContent", ""),
-                        speed=sch.get("Speed", 1.0),
-                        pitch=sch.get("Pitch", 1.0),
-                    )
-                    play_mp3(audio)
-                    sch["last_run"] = now
-                except Exception as e:  # noqa: BLE001
-                    print(f"Failed to play schedule {sch.get('ScheduleID')}: {e}")
-                finally:
                     sch["next_run"] = compute_next_run(
                         sch, now + dt.timedelta(seconds=1)
                     )
+                    continue
+                sch["next_run"] = None
+                task = asyncio.create_task(_run_schedule(sch))
+                pending_tasks.add(task)
+                task.add_done_callback(pending_tasks.discard)
         await asyncio.sleep(1)
 
 


### PR DESCRIPTION
## Summary
- run each due broadcast in its own task so a slow TTS request doesn't block others
- maintain a set of pending tasks and compute the next run when the task finishes

## Testing
- `python -m py_compile scheduler.py`
- `python - <<'PY'
import asyncio, threading, datetime as dt
import scheduler
async def fake_tts(text, speed=1.0, pitch=1.0):
    print('fake_tts called with:', text)
    await asyncio.sleep(0.5)
    return b''
scheduler.tts_request = fake_tts
schedules=[{"ScheduleID":1,"Title":"Test","ScheduledTime":(dt.datetime.now()+dt.timedelta(seconds=1)).time().isoformat()}]
async def main():
    stop_event=threading.Event()
    task=asyncio.create_task(scheduler.scheduler_loop(schedules, stop_event))
    await asyncio.sleep(3)
    stop_event.set()
    await task
asyncio.run(main())
PY`

------
https://chatgpt.com/codex/tasks/task_e_68aa9b82d7c48324a4a4146e724c74de