### PR TITLE
Use fixed HTTPS server address

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,8 @@ systems where `h2` is missing.
 
 ## Running
 
-Edit `client.cfg` with your `HOST`, `API_KEY` and `DEVICE_ID`, then run:
+Edit `client.cfg` with your `API_KEY` and `DEVICE_ID` (the host is fixed to
+`https://pc.flexx.kr:65000`), then run:
 
 ```bash
 python enterplayer.py

--- a/enterplayer.py
+++ b/enterplayer.py
@@ -23,6 +23,8 @@ import display_config
 # Directory where the script or executable is running
 RUN_DIR = pathlib.Path(sys.argv[0]).resolve().parent
 
+HOST_URL = "https://pc.flexx.kr:65000"
+
 """Simple Tk GUI client with a system tray icon.
 
 서버 연결 후 `/broadcast-schedules` 를 호출해 방송 예약 목록을 출력한다.
@@ -61,7 +63,7 @@ def get_mac_address() -> str:
 def load_config():
     if not CFG_PATH.exists():
         sample = {
-            "HOST": "http://example.com:65000",
+            "HOST": HOST_URL,
             "API_KEY": "",
             "DEVICE_ID": "PC-CLIENT",
             "MAC_ADDRESS": get_mac_address(),
@@ -70,7 +72,11 @@ def load_config():
         print(f"Created {CFG_PATH}. Fill in API_KEY and run again.")
         sys.exit(1)
     with CFG_PATH.open("r", encoding="utf-8") as f:
-        return json.load(f)
+        cfg = json.load(f)
+    if cfg.get("HOST") != HOST_URL:
+        cfg["HOST"] = HOST_URL
+        CFG_PATH.write_text(json.dumps(cfg, indent=2), encoding="utf-8")
+    return cfg
 
 
 def save_config(config: dict) -> None:

--- a/scheduler.py
+++ b/scheduler.py
@@ -11,6 +11,8 @@ from typing import Any, Dict, List, Optional
 
 import httpx
 
+HOST_URL = "https://pc.flexx.kr:65000"
+
 # When packaged as a single executable on Windows, ``__file__`` points to a
 # temporary extraction directory. Use ``sys.argv[0]`` so ``client.cfg`` is
 # loaded from the executable's directory.
@@ -26,7 +28,7 @@ RUN_DIR = pathlib.Path(sys.argv[0]).resolve().parent
 def load_config() -> Dict[str, Any]:
     if not CFG_PATH.exists():
         sample = {
-            "HOST": "http://example.com:65000",
+            "HOST": HOST_URL,
             "API_KEY": "",
             "DEVICE_ID": "PC-CLIENT",
         }
@@ -34,7 +36,11 @@ def load_config() -> Dict[str, Any]:
         print(f"Created {CFG_PATH}. Fill in API_KEY and run again.")
         sys.exit(1)
     with CFG_PATH.open("r", encoding="utf-8") as f:
-        return json.load(f)
+        cfg = json.load(f)
+    if cfg.get("HOST") != HOST_URL:
+        cfg["HOST"] = HOST_URL
+        CFG_PATH.write_text(json.dumps(cfg, indent=2), encoding="utf-8")
+    return cfg
 
 
 def _cleanup_process(proc: subprocess.Popen, path: str) -> None:


### PR DESCRIPTION
## Summary
- force client config to use https://pc.flexx.kr:65000
- update default configuration and docs for fixed secure host

## Testing
- `python -m py_compile scheduler.py enterplayer.py`


------
https://chatgpt.com/codex/tasks/task_e_68aaa99016dc83248fb46b3616a9d1af