### PR TITLE
Fix server host

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ systems where `h2` is missing.
 
 ## Running
 
-Edit `client.cfg` with your `HOST`, `API_KEY` and `DEVICE_ID`, then run:
+Edit `client.cfg` with your `API_KEY` and `DEVICE_ID` (the server address is fixed to `https://pc.flexx.kr:65000`), then run:
 
 ```bash
 python enterplayer.py

--- a/enterplayer.py
+++ b/enterplayer.py
@@ -20,6 +20,8 @@ import vlc_embed
 import vlc_playlist
 import display_config
 
+HOST_URL = "https://pc.flexx.kr:65000"
+
 # Directory where the script or executable is running
 RUN_DIR = pathlib.Path(sys.argv[0]).resolve().parent
 
@@ -61,7 +63,7 @@ def get_mac_address() -> str:
 def load_config():
     if not CFG_PATH.exists():
         sample = {
-            "HOST": "http://example.com:65000",
+            "HOST": HOST_URL,
             "API_KEY": "",
             "DEVICE_ID": "PC-CLIENT",
             "MAC_ADDRESS": get_mac_address(),
@@ -70,7 +72,10 @@ def load_config():
         print(f"Created {CFG_PATH}. Fill in API_KEY and run again.")
         sys.exit(1)
     with CFG_PATH.open("r", encoding="utf-8") as f:
-        return json.load(f)
+        cfg = json.load(f)
+    cfg["HOST"] = HOST_URL
+    save_config(cfg)
+    return cfg
 
 
 def save_config(config: dict) -> None:
@@ -79,7 +84,7 @@ def save_config(config: dict) -> None:
 
 
 cfg = load_config()
-HOST = cfg["HOST"].rstrip("/")
+HOST = HOST_URL.rstrip("/")
 API_KEY = cfg["API_KEY"]
 DEVICE_ID = cfg["DEVICE_ID"]
 if cfg.get("MAC_ADDRESS"):

--- a/scheduler.py
+++ b/scheduler.py
@@ -22,11 +22,13 @@ else:
 # Directory to store temporary media next to the running executable/script
 RUN_DIR = pathlib.Path(sys.argv[0]).resolve().parent
 
+HOST = "https://pc.flexx.kr:65000"
+
 
 def load_config() -> Dict[str, Any]:
     if not CFG_PATH.exists():
         sample = {
-            "HOST": "http://example.com:65000",
+            "HOST": HOST,
             "API_KEY": "",
             "DEVICE_ID": "PC-CLIENT",
         }
@@ -34,7 +36,10 @@ def load_config() -> Dict[str, Any]:
         print(f"Created {CFG_PATH}. Fill in API_KEY and run again.")
         sys.exit(1)
     with CFG_PATH.open("r", encoding="utf-8") as f:
-        return json.load(f)
+        cfg = json.load(f)
+    cfg["HOST"] = HOST
+    CFG_PATH.write_text(json.dumps(cfg, indent=2), encoding="utf-8")
+    return cfg
 
 
 def _cleanup_process(proc: subprocess.Popen, path: str) -> None:
@@ -158,9 +163,8 @@ def compute_next_run(sch: Dict[str, Any], base: Optional[dt.datetime] = None) ->
 
 
 async def fetch_schedules(cfg: Dict[str, Any]) -> List[Dict[str, Any]]:
-    base_url = cfg["HOST"].rstrip("/")
     headers = {"X-API-Key": cfg["API_KEY"]}
-    async with httpx.AsyncClient(base_url=base_url, http2=True, timeout=5.0) as cli:
+    async with httpx.AsyncClient(base_url=HOST, http2=True, timeout=5.0) as cli:
         r = await cli.get("/broadcast-schedules", headers=headers)
         r.raise_for_status()
         data = r.json()


### PR DESCRIPTION
## Summary
- force server host to `https://pc.flexx.kr:65000`
- update documentation accordingly

## Testing
- `python -m py_compile enterplayer.py scheduler.py`


------
https://chatgpt.com/codex/tasks/task_e_68aaa99016dc83248fb46b3616a9d1af