### PR TITLE
Include sdk folder in PyInstaller build

### DIFF
--- a/enterplayer.spec
+++ b/enterplayer.spec
@@ -20,15 +20,13 @@ a = Analysis(
 # 2) 파이썬 코드 → 압축된 pyz
 pyz = PYZ(a.pure, a.zipped_data, cipher=block_cipher)
 
-# 3) 실행 파일 생성 ─ onefile=True 가 핵심
+# 3) 실행 파일 생성 ─ onedir 모드
 exe = EXE(
     pyz,
     a.scripts,
-    a.binaries,
-    a.zipfiles,
-    a.datas,
     [],
-    name='enterplayer',           # dist/enterplayer.exe
+    exclude_binaries=True,
+    name='enterplayer',           # dist/enterplayer/enterplayer.exe
     debug=False,
     bootloader_ignore_signals=False,
     strip=False,
@@ -40,5 +38,19 @@ exe = EXE(
     codesign_identity=None,
     entitlements_file=None,
     icon=None,                   # 아이콘 넣으려면 'icon.ico'
-    onefile=True                 # ★ 단일 EXE 플래그
+    contents_directory='.',
+    onefile=False                # 폴더 구조 유지
+)
+
+# 4) 결과물에 sdk 폴더 포함
+coll = COLLECT(
+    exe,
+    a.binaries,
+    a.zipfiles,
+    a.datas,
+    Tree('sdk', prefix='sdk'),
+    strip=False,
+    upx=True,
+    upx_exclude=[],
+    name='enterplayer'
 )


### PR DESCRIPTION
## Summary
- ensure onedir build produces `enterplayer` executable alongside an `sdk` folder
- configure spec to expose bundled files at top level for easier deployment

## Testing
- `pip install pyinstaller >/tmp/pip.log && tail -n 20 /tmp/pip.log`
- `pyinstaller enterplayer.spec --clean >/tmp/pyinstaller.log && tail -n 20 /tmp/pyinstaller.log`
- `ls dist/enterplayer`


------
https://chatgpt.com/codex/tasks/task_e_68b19a8a1b48832487bebaa9ed34e2cd