### PR TITLE
Respect scheduled broadcast volume settings

### DIFF
--- a/scheduler.py
+++ b/scheduler.py
@@ -193,6 +193,17 @@ async def scheduler_loop(
                     print(
                         f"Playing schedule {sch.get('ScheduleID')}: {sch.get('Title')}"
                     )
+                    volume = sch.get("Volume")
+                    if volume is None:
+                        volume = sch.get("volume")
+                    if volume is not None:
+                        try:
+                            set_volume(int(volume))
+                        except (TypeError, ValueError):
+                            print(
+                                f"Invalid volume value {volume!r} for schedule {sch.get('ScheduleID')}"
+                            )
+
                     audio = await tts_request(
                         sch.get("TTSContent", ""),
                         speed=sch.get("Speed", 1.0),


### PR DESCRIPTION
## Summary
- read the volume value from each schedule entry before playback
- apply the requested volume via the existing scheduler.set_volume helper
- log a warning when the schedule contains an invalid volume value

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ff50435cc083248ac1da85aa82bf30