### PR TITLE
Respect schedule volume settings

### DIFF
--- a/enterplayer.py
+++ b/enterplayer.py
@@ -332,6 +332,17 @@ class WSClient:
 
     async def play_schedule(self, sch: dict) -> None:
         """Fetch TTS audio for a schedule and play it."""
+        volume = sch.get("Volume")
+        if volume is None:
+            volume = sch.get("volume")
+        if volume is not None:
+            try:
+                scheduler.set_volume(int(float(volume)))
+            except Exception as exc:  # noqa: BLE001
+                self.log(
+                    f"Failed to set schedule volume {volume!r}: {exc}",
+                    logging.WARNING,
+                )
         audio = await scheduler.tts_request(
             sch.get("TTSContent", ""),
             speed=sch.get("Speed", 1.0),

--- a/scheduler.py
+++ b/scheduler.py
@@ -193,6 +193,17 @@ async def scheduler_loop(
                     print(
                         f"Playing schedule {sch.get('ScheduleID')}: {sch.get('Title')}"
                     )
+                    volume = sch.get("Volume")
+                    if volume is None:
+                        volume = sch.get("volume")
+                    if volume is not None:
+                        try:
+                            set_volume(int(float(volume)))
+                        except Exception as exc:  # noqa: BLE001
+                            print(
+                                "Failed to set schedule volume "
+                                f"{volume!r}: {exc}"
+                            )
                     audio = await tts_request(
                         sch.get("TTSContent", ""),
                         speed=sch.get("Speed", 1.0),


### PR DESCRIPTION
## Summary
- apply schedule-provided volume before starting reserved broadcasts in the standalone scheduler
- mirror the same volume handling when the GUI client triggers a scheduled playback

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ff50435cc083248ac1da85aa82bf30